### PR TITLE
Feature/product system

### DIFF
--- a/src/main/java/com/business/i4_be/domain/product/constants/ProductStatus.java
+++ b/src/main/java/com/business/i4_be/domain/product/constants/ProductStatus.java
@@ -1,0 +1,7 @@
+package com.business.i4_be.domain.product.constants;
+
+public enum ProductStatus {
+  HIDDEN,
+  SOLD_OUT,
+  SALE
+}

--- a/src/main/java/com/business/i4_be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/business/i4_be/domain/product/controller/ProductController.java
@@ -1,0 +1,72 @@
+package com.business.i4_be.domain.product.controller;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.business.i4_be.domain.product.dto.AddProductReqDto;
+import com.business.i4_be.domain.product.dto.AddProductResDto;
+import com.business.i4_be.domain.product.dto.ProductResDto;
+import com.business.i4_be.domain.product.dto.ProductsResDto;
+import com.business.i4_be.domain.product.dto.UpdateProductReqDto;
+import com.business.i4_be.domain.product.dto.UpdateProductResDto;
+import com.business.i4_be.domain.product.service.ProductService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+  private final ProductService productService;
+
+  @PostMapping
+  public ResponseEntity<AddProductResDto> addProduct(
+      @Valid @RequestBody AddProductReqDto requestDto) {
+    return ResponseEntity.status(CREATED).body(productService.addProduct(requestDto));
+  }
+
+  @PutMapping("/{productId}")
+  public ResponseEntity<UpdateProductResDto> updateProduct(
+      @PathVariable("productId") UUID productId,
+      @Valid @RequestBody UpdateProductReqDto requestDto
+  ) {
+    return ResponseEntity.ok().body(productService.updateProduct(productId, requestDto));
+  }
+
+  @DeleteMapping("/{productId}")
+  public ResponseEntity<Void> deleteProduct(
+      @PathVariable("productId") UUID productId,
+      @RequestParam("storeId") UUID storeId
+  ) {
+    return ResponseEntity.ok().body(productService.deleteProduct(storeId, productId));
+  }
+
+  @GetMapping("/{productId}")
+  public ResponseEntity<ProductResDto> getProduct(
+      @PathVariable("productId") UUID productId,
+      @RequestParam("storeId") UUID storeId
+  ) {
+    return ResponseEntity.ok().body(productService.getProduct(storeId, productId));
+  }
+
+  @GetMapping
+  public ResponseEntity<ProductsResDto> searchProducts(
+      @RequestParam("storeId") UUID storeId,
+      @RequestParam("keyword") String keyword
+  ) {
+    return ResponseEntity.ok().body(productService.searchProducts(storeId, keyword));
+  }
+}

--- a/src/main/java/com/business/i4_be/domain/product/controller/ProductOwnerController.java
+++ b/src/main/java/com/business/i4_be/domain/product/controller/ProductOwnerController.java
@@ -1,0 +1,24 @@
+package com.business.i4_be.domain.product.controller;
+
+import com.business.i4_be.domain.product.dto.ProductsResDto;
+import com.business.i4_be.domain.product.service.ProductService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/owner/v1/products")
+@RequiredArgsConstructor
+public class ProductOwnerController {
+
+  private final ProductService productService;
+
+  @GetMapping
+  public ResponseEntity<ProductsResDto> getProducts(@RequestParam("storeId") UUID storeId) {
+    return ResponseEntity.ok().body(productService.getProducts(storeId));
+  }
+}

--- a/src/main/java/com/business/i4_be/domain/product/dto/AddProductReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/AddProductReqDto.java
@@ -1,0 +1,41 @@
+package com.business.i4_be.domain.product.dto;
+
+import com.business.i4_be.domain.product.constants.ProductStatus;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class AddProductReqDto {
+
+  @NotNull
+  private UUID storeId;
+
+  @Valid
+  private Product product;
+
+  @Getter
+  public static class Product {
+
+    @NotBlank(message = "상품명은 필수입니다.")
+    private String productName;
+
+    @PositiveOrZero(message = "0이상의 값을 입력해야 합니다.")
+    private Integer quantity;
+
+    @NotNull(message = "가격은 최소 100원 이상이어야 합니다.")
+    @Min(value = 100, message = "가격은 최소 100원 이상이어야 합니다.")
+    private Integer price;
+
+    private String text;
+
+    @NotNull
+    private ProductStatus status;
+
+    private String imageUrl;
+  }
+}

--- a/src/main/java/com/business/i4_be/domain/product/dto/AddProductResDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/AddProductResDto.java
@@ -1,0 +1,48 @@
+package com.business.i4_be.domain.product.dto;
+
+import com.business.i4_be.domain.product.constants.ProductStatus;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AddProductResDto {
+
+  private Product product;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  private static class Product {
+    private UUID productId;
+    private String productName;
+    private Integer quantity;
+    private Integer price;
+    private String text;
+    private ProductStatus status;
+    private String imageUrl;
+  }
+
+  public static AddProductResDto from(com.business.i4_be.domain.product.entity.Product product) {
+    Product addProduct = Product.builder()
+        .productId(product.getProductId())
+        .productName(product.getProductName())
+        .quantity(product.getQuantity())
+        .price(product.getPrice())
+        .text(product.getText())
+        .status(product.getStatus())
+        .imageUrl(product.getImage())
+        .build();
+
+    return AddProductResDto.builder()
+        .product(addProduct)
+        .build();
+  }
+}

--- a/src/main/java/com/business/i4_be/domain/product/dto/ProductResDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/ProductResDto.java
@@ -1,0 +1,56 @@
+package com.business.i4_be.domain.product.dto;
+
+import com.business.i4_be.domain.product.constants.ProductStatus;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductResDto {
+
+  private UUID storeId;
+  private Product product;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  private static class Product {
+
+    private UUID productId;
+    private String productName;
+    private Integer quantity;
+    private Integer price;
+    private String text;
+    private ProductStatus status;
+    private String imageUrl;
+
+    public static Product from(com.business.i4_be.domain.product.entity.Product product) {
+      return Product.builder()
+          .productId(product.getProductId())
+          .productName(product.getProductName())
+          .quantity(product.getQuantity())
+          .price(product.getPrice())
+          .text(product.getText())
+          .status(product.getStatus())
+          .imageUrl(product.getImage())
+          .build();
+    }
+  }
+
+  public static ProductResDto from(UUID storeId,
+      com.business.i4_be.domain.product.entity.Product product) {
+    Product getProduct = Product.from(product);
+
+    return ProductResDto.builder()
+        .storeId(storeId)
+        .product(getProduct)
+        .build();
+  }
+}

--- a/src/main/java/com/business/i4_be/domain/product/dto/ProductsResDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/ProductsResDto.java
@@ -1,0 +1,56 @@
+package com.business.i4_be.domain.product.dto;
+
+import com.business.i4_be.domain.product.constants.ProductStatus;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductsResDto {
+
+  private UUID storeId;
+  private List<Product> products;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  private static class Product {
+    private UUID productId;
+    private String productName;
+    private Integer quantity;
+    private Integer price;
+    private String text;
+    private ProductStatus status;
+    private String imageUrl;
+
+    public static Product from(com.business.i4_be.domain.product.entity.Product product) {
+      return Product.builder()
+          .productId(product.getProductId())
+          .productName(product.getProductName())
+          .quantity(product.getQuantity())
+          .price(product.getPrice())
+          .text(product.getText())
+          .status(product.getStatus())
+          .imageUrl(product.getImage())
+          .build();
+    }
+  }
+
+  public static ProductsResDto from(UUID storeId, List<com.business.i4_be.domain.product.entity.Product> products) {
+    List<Product> productList = products.stream()
+        .map(Product::from).toList();
+
+    return ProductsResDto.builder()
+        .storeId(storeId)
+        .products(productList)
+        .build();
+  }
+}

--- a/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductReqDto.java
@@ -1,0 +1,41 @@
+package com.business.i4_be.domain.product.dto;
+
+import com.business.i4_be.domain.product.constants.ProductStatus;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class UpdateProductReqDto {
+
+  @NotNull
+  private UUID storeId;
+
+  @Valid
+  private Product product;
+
+  @Getter
+  public static class Product {
+
+    @NotBlank(message = "상품명은 필수입니다.")
+    private String productName;
+
+    @PositiveOrZero(message = "0이상의 값을 입력해야 합니다.")
+    private Integer quantity;
+
+    @NotNull(message = "가격은 최소 100원 이상이어야 합니다.")
+    @Min(value = 100, message = "가격은 최소 100원 이상이어야 합니다.")
+    private Integer price;
+
+    private String text;
+
+    @NotNull
+    private ProductStatus status;
+
+    private String imageUrl;
+  }
+}

--- a/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductResDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductResDto.java
@@ -1,0 +1,48 @@
+package com.business.i4_be.domain.product.dto;
+
+import com.business.i4_be.domain.product.constants.ProductStatus;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateProductResDto {
+
+  private Product product;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  private static class Product {
+    private UUID productId;
+    private String productName;
+    private Integer quantity;
+    private Integer price;
+    private String text;
+    private ProductStatus status;
+    private String imageUrl;
+  }
+
+  public static UpdateProductResDto from(com.business.i4_be.domain.product.entity.Product product) {
+    UpdateProductResDto.Product updateProduct = UpdateProductResDto.Product.builder()
+        .productId(product.getProductId())
+        .productName(product.getProductName())
+        .quantity(product.getQuantity())
+        .price(product.getPrice())
+        .text(product.getText())
+        .status(product.getStatus())
+        .imageUrl(product.getImage())
+        .build();
+
+    return UpdateProductResDto.builder()
+        .product(updateProduct)
+        .build();
+  }
+}

--- a/src/main/java/com/business/i4_be/domain/product/entity/Product.java
+++ b/src/main/java/com/business/i4_be/domain/product/entity/Product.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "product")
+@Table(name = "p_products")
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/business/i4_be/domain/product/entity/Product.java
+++ b/src/main/java/com/business/i4_be/domain/product/entity/Product.java
@@ -1,0 +1,48 @@
+package com.business.i4_be.domain.product.entity;
+
+import com.business.i4_be.domain.product.constants.ProductStatus;
+import com.business.i4_be.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "product")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Product extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(columnDefinition = "uuid", nullable = false, updatable = false)
+  private UUID productId;
+
+  @Column(nullable = false)
+  private String productName;
+
+  private Integer quantity;
+
+  @Column(nullable = false)
+  private Integer price;
+
+  private String text;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private ProductStatus status;
+
+  private String image;
+}

--- a/src/main/java/com/business/i4_be/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/business/i4_be/domain/product/repository/ProductRepository.java
@@ -1,0 +1,13 @@
+package com.business.i4_be.domain.product.repository;
+
+import com.business.i4_be.domain.product.entity.Product;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, UUID> {
+
+  Optional<Product> findByProductId(UUID productId);
+}

--- a/src/main/java/com/business/i4_be/domain/product/service/ProductService.java
+++ b/src/main/java/com/business/i4_be/domain/product/service/ProductService.java
@@ -1,0 +1,43 @@
+package com.business.i4_be.domain.product.service;
+
+import com.business.i4_be.domain.product.dto.AddProductReqDto;
+import com.business.i4_be.domain.product.dto.AddProductResDto;
+import com.business.i4_be.domain.product.dto.ProductResDto;
+import com.business.i4_be.domain.product.dto.ProductsResDto;
+import com.business.i4_be.domain.product.dto.UpdateProductReqDto;
+import com.business.i4_be.domain.product.dto.UpdateProductResDto;
+import com.business.i4_be.domain.product.repository.ProductRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+  private final ProductRepository productRepository;
+
+  public AddProductResDto addProduct(AddProductReqDto requestDto) {
+    return null;
+  }
+
+  public UpdateProductResDto updateProduct(UUID productId, UpdateProductReqDto requestDto) {
+    return null;
+  }
+
+  public Void deleteProduct(UUID storeId, UUID productId) {
+    return null;
+  }
+
+  public ProductResDto getProduct(UUID storeId, UUID productId) {
+    return null;
+  }
+
+  public ProductsResDto searchProducts(UUID storeId, String keyword) {
+    return null;
+  }
+
+  public ProductsResDto getProducts(UUID storeId) {
+    return null;
+  }
+}

--- a/src/main/java/com/business/i4_be/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/business/i4_be/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.business.i4_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/business/i4_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/business/i4_be/global/exception/ErrorCode.java
@@ -10,10 +10,12 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
   /**
-   * domain 별로
+   * domain 별로 코드 관리
+   * Bean Validation 같은 공통 예외는 0
    */
-  USER_NOT_FOUND(NOT_FOUND.value(), "유저가 존재하지 않습니다.");
+  USER_NOT_FOUND(1000, NOT_FOUND.value(), "유저가 존재하지 않습니다.");
 
+  private final int code; // 도메인 관리 코드
   private final int status;
   private final String message;
 }

--- a/src/main/java/com/business/i4_be/global/exception/ErrorResponse.java
+++ b/src/main/java/com/business/i4_be/global/exception/ErrorResponse.java
@@ -9,6 +9,6 @@ public class ErrorResponse {
 
   private final int code;
   private final int status;
-  private final String message; ;
+  private final String message;
 
 }

--- a/src/main/java/com/business/i4_be/global/exception/ErrorResponse.java
+++ b/src/main/java/com/business/i4_be/global/exception/ErrorResponse.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ErrorResponse {
 
+  private final int code;
   private final int status;
-  private final String message;
+  private final String message; ;
 
 }

--- a/src/main/java/com/business/i4_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/business/i4_be/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,10 @@
 package com.business.i4_be.global.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -9,7 +13,20 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(CustomException.class)
   public ResponseEntity<ErrorResponse> handleCustomException(final CustomException e) {
-    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode().getStatus(), e.getMessage());
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode().getCode(), e.getErrorCode().getStatus(), e.getMessage());
     return ResponseEntity.status(e.getErrorCode().getStatus()).body(errorResponse);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+      final MethodArgumentNotValidException e) {
+    StringBuilder sb = new StringBuilder();
+    e.getBindingResult().getFieldErrors()
+        .stream().map(DefaultMessageSourceResolvable::getDefaultMessage)
+        .forEach(message -> sb.append(message).append("\n"));
+
+    String errorMessages = sb.toString();
+    ErrorResponse errorResponse = new ErrorResponse(0,BAD_REQUEST.value(), errorMessages);
+    return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
   }
 }

--- a/src/test/java/com/business/i4_be/domain/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/business/i4_be/domain/product/repository/ProductRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.business.i4_be.domain.product.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.business.i4_be.domain.product.constants.ProductStatus;
+import com.business.i4_be.domain.product.entity.Product;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProductRepositoryTest {
+
+  @Autowired
+  ProductRepository productRepository;
+
+  Product product;
+
+  @Test
+  @DisplayName("Product Save 성공")
+  @Rollback(false)
+  void product_save() {
+    //when
+    product = makeProduct();
+
+    Product saveProduct = productRepository.save(product);
+    Optional<Product> getProduct = productRepository.findByProductId(product.getProductId());
+
+    //then
+    assertThat(getProduct).isPresent();
+    assertEquals(saveProduct.getProductId(), getProduct.get().getProductId());
+    assertEquals(saveProduct.getProductName(), getProduct.get().getProductName());
+    assertEquals(saveProduct.getQuantity(), getProduct.get().getQuantity());
+    assertEquals(saveProduct.getPrice(), getProduct.get().getPrice());
+    assertEquals(saveProduct.getText(), getProduct.get().getText());
+    assertEquals(saveProduct.getStatus(), getProduct.get().getStatus());
+  }
+
+  private Product makeProduct() {
+    return Product.builder()
+        .productName("Test Product")
+        .quantity(100)
+        .price(1000)
+        .text("테스트 상품입니다.")
+        .status(ProductStatus.SALE)
+        .build();
+  }
+}


### PR DESCRIPTION
### 📌 작업 내용
이 PR에서 추가된 기능 또는 수정 사항에 대해 간략히 설명해주세요.
- As-is
  - (변경 전 설명을 여기에 작성)
- To-be
  - Product 도메인에서 6가지 API를 비즈니스 로직을 제외하고 구현했습니다. 종류는 다음과 같습니다.
  - OWNER 권한 이상(상품 등록, 상품 수정, 상품 삭제, 내 가게 상품 조회),  모두 권한(상품 단건 조회, 상품 검색)
  - Bean Validation에 대한 글로벌 예외처리를 추가 했습니다.
  - JpaAuditingConfig를 추가 했습니다.
  - 예외 관리에서 int 타입의 code 변수를 추가했습니다. 이유는 밑에 기술합니다.

### 🧑‍💻 작업 유형
- [O] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 설정 변경
- [ ] CI/CD 변경

### 📷 관련 이미지
해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### 🚨 주의 사항
- JpaAuditingConfig를 Global - config 패키지에 작성했습니다. pull 시 충돌이 발생할 수 있습니다.
- Bean Validation 예외를 처리할 때, 발생하는 예외가 2개 이상이면 예외 메시지를 StringBuilder로 \n를 추가해서 여러 줄이 작성되게 구현했습니다. 테스트에서는 \n 문자열이 출력되지만, 크롬 console에서 보면 정상적으로 띄어쓰기가 되서 출력됩니다.

### 🤔 토론
int code 변수를 추가한 이유는 도메인을 상태 코드로 관리하기 위함힙니다. 예를 들어, User 도메인에서 발생한 예외일 경우 1000, Store도메인에서 발생하면 2000, 이런식으로 팀에서 커스터마이징 해서 관리할 수 있습니다. 만약 도메인이 애매한 공통 예외일 경우 일단 0으로 정했습니다.
--> 상태코드는 개발을 진행하면서 각각 부여하면 좋을 것 같습니다. 