### PR TITLE
Feature/store crud

### DIFF
--- a/src/main/java/com/business/i4_be/domain/order/constant/OrderType.java
+++ b/src/main/java/com/business/i4_be/domain/order/constant/OrderType.java
@@ -1,0 +1,6 @@
+package com.business.i4_be.domain.order.constant;
+
+public enum OrderType {
+    DELIVERY,
+    TAKEOUT
+}

--- a/src/main/java/com/business/i4_be/domain/store/constant/StoreCategory.java
+++ b/src/main/java/com/business/i4_be/domain/store/constant/StoreCategory.java
@@ -15,4 +15,14 @@ public enum StoreCategory {
     StoreCategory(String description) {
         this.description = description;
     }
+    //주어진 카테고리 유효한지 체크하는 메서드
+    public static boolean isValidCategory(String category) {
+        try {
+            StoreCategory.valueOf(category.toUpperCase());  // Enum에 존재하는지 확인
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
 }

--- a/src/main/java/com/business/i4_be/domain/store/controller/StoreController.java
+++ b/src/main/java/com/business/i4_be/domain/store/controller/StoreController.java
@@ -4,7 +4,6 @@ import com.business.i4_be.domain.store.dto.StoreReqDto;
 import com.business.i4_be.domain.store.dto.StoreUpdateReqDto;
 import com.business.i4_be.domain.store.dto.StoreListResDto;
 import com.business.i4_be.domain.store.dto.StoreResDto;
-import com.business.i4_be.domain.store.entity.Store;
 import com.business.i4_be.domain.store.service.StoreService;
 
 import jakarta.validation.Valid;
@@ -21,92 +20,65 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    /**
-    * 가게 등록 (ADMIN, MASTER)
-    * */
+    //가게 등록
     @PostMapping("/v1/stores")
     public ResponseEntity<StoreResDto> createStore(@Valid @RequestBody StoreReqDto reqDto) {
-
         StoreResDto newStore = storeService.createStore(reqDto);
         return ResponseEntity.ok(newStore);
 
     }
-    /**
-     * 개별 가게 상세 조회 (ALL)
-     */
+    //가게 조회(단건)
     @GetMapping("/v1/stores/{storeId}")
     public ResponseEntity<StoreResDto> getStore(@PathVariable UUID storeId) {
-        StoreResDto store = storeService.getStoreById(storeId);
+        StoreResDto store = storeService.getStore(storeId);
         return ResponseEntity.ok(store);
     }
-    /**
-     * 가게 전체 조회(ALL)
-     * */
+
+    //가게 조회(목록)
     @GetMapping("/v1/stores")
     public ResponseEntity<StoreListResDto> getAllStores() {
-        StoreListResDto listResponse = storeService.getAllStores();
-        return ResponseEntity.ok(listResponse);
+        StoreListResDto stores = storeService.getAllStores();
+        return ResponseEntity.ok(stores);
     }
 
-    /**
-     * 가게 수정 (ADMIN, MASTER, OWNER)
-     */
+    //가게 수정
     @PutMapping("/owner/v1/stores/{storeId}")
     public ResponseEntity<StoreResDto> updateStore(@PathVariable UUID storeId,
-                                                   @Valid @RequestBody StoreUpdateReqDto updateDto) {
-        StoreResDto updatedStore = storeService.updateStore(storeId, updateDto);
+                                                   @Valid @RequestBody StoreUpdateReqDto updateReqDto) {
+        StoreResDto updatedStore = storeService.updateStore(storeId, updateReqDto);
         return ResponseEntity.ok(updatedStore);
     }
 
 
-    /**
-     * 가게 삭제 (MASTER)
-     */
+    //가게 삭제
     @DeleteMapping("/v1/stores/{storeId}")
     public ResponseEntity<Void> deleteStore(@PathVariable UUID storeId) {
         storeService.deleteStore(storeId);
         return ResponseEntity.noContent().build();
     }
 
-
-    /**
-     * 삭제된 가게 조회 (is_delete = Ture)
-     * */
-    @GetMapping("/v1/stores/deleted")
-    public ResponseEntity<List<Store>> getDeletedStores() {
-        List<Store> deletedStores = storeService.getDeletedStores();
-        return ResponseEntity.ok(deletedStores);
-    }
-    /**
-     * 카테고리별 가게 조회 (ALL)
-     */
+    //가게 검색(카테고리)
     @GetMapping("/v1/stores/category")
     public ResponseEntity<List<StoreResDto>> getStoresByCategory(@RequestParam String category) {
-        List<StoreResDto> result = storeService.getStoresByCategory(category);
-        return ResponseEntity.ok(result);
+        List<StoreResDto> stores = storeService.getStoresByCategory(category);
+        return ResponseEntity.ok(stores);
     }
-    /**
-     * 가게 이름으로 검색 (ALL)
-     */
+    //가게 검색(이름)
     @GetMapping("/v1/stores/search")
     public ResponseEntity<List<StoreResDto>> searchStoresByName(@RequestParam String keyword) {
-        List<StoreResDto> result = storeService.searchStoresByName(keyword);
-        return ResponseEntity.ok(result);
+        List<StoreResDto> stores = storeService.searchStoresByName(keyword);
+        return ResponseEntity.ok(stores);
     }
-    /**
-     * 가게 상태 변경 (ADMIN, MASTER, OWNER)
-     */
+    //가게 변경(상태만)
     @PatchMapping("/owner/v1/stores/{storeId}/status")
     public ResponseEntity<StoreResDto> updateStoreStatus(@PathVariable UUID storeId,
                                                          @RequestBody Map<String, String> requestBody) {
-        String statusStr = requestBody.get("isOpen");
-        StoreResDto updatedStore = storeService.updateStoreStatus(storeId, statusStr);
+        String isOpen = requestBody.get("isOpen");
+        StoreResDto updatedStore = storeService.updateStoreStatus(storeId, isOpen);
         return ResponseEntity.ok(updatedStore);
     }
 
-    /**
-     * 가게 카테고리 변경 (ADMIN, MASTER, OWNER)
-     */
+    //가게 변경(카테고리만)
     @PatchMapping("/owner/v1/stores/{storeId}/category")
     public ResponseEntity<StoreResDto> updateStoreCategory(@PathVariable UUID storeId,
                                                            @RequestBody Map<String, String> requestBody) {
@@ -114,7 +86,6 @@ public class StoreController {
         StoreResDto updatedStore = storeService.updateStoreCategory(storeId, categoryStr);
         return ResponseEntity.ok(updatedStore);
     }
-
 }
 
 

--- a/src/main/java/com/business/i4_be/domain/store/controller/StoreController.java
+++ b/src/main/java/com/business/i4_be/domain/store/controller/StoreController.java
@@ -1,0 +1,130 @@
+package com.business.i4_be.domain.store.controller;
+
+import com.business.i4_be.domain.store.dto.StoreReqDto;
+import com.business.i4_be.domain.store.dto.StoreUpdateReqDto;
+import com.business.i4_be.domain.store.dto.StoreListResDto;
+import com.business.i4_be.domain.store.dto.StoreResDto;
+import com.business.i4_be.domain.store.entity.Store;
+import com.business.i4_be.domain.store.service.StoreService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    /**
+    * 가게 등록 (ADMIN, MASTER)
+    * */
+    @PostMapping("/v1/stores")
+    public ResponseEntity<StoreResDto> createStore(@Valid @RequestBody StoreReqDto reqDto) {
+
+        StoreResDto newStore = storeService.createStore(reqDto);
+        return ResponseEntity.ok(newStore);
+
+    }
+    /**
+     * 개별 가게 상세 조회 (ALL)
+     */
+    @GetMapping("/v1/stores/{storeId}")
+    public ResponseEntity<StoreResDto> getStore(@PathVariable UUID storeId) {
+        StoreResDto store = storeService.getStoreById(storeId);
+        return ResponseEntity.ok(store);
+    }
+    /**
+     * 가게 전체 조회(ALL)
+     * */
+    @GetMapping("/v1/stores")
+    public ResponseEntity<StoreListResDto> getAllStores() {
+        StoreListResDto listResponse = storeService.getAllStores();
+        return ResponseEntity.ok(listResponse);
+    }
+
+    /**
+     * 가게 수정 (ADMIN, MASTER, OWNER)
+     */
+    @PutMapping("/owner/v1/stores/{storeId}")
+    public ResponseEntity<StoreResDto> updateStore(@PathVariable UUID storeId,
+                                                   @Valid @RequestBody StoreUpdateReqDto updateDto) {
+        StoreResDto updatedStore = storeService.updateStore(storeId, updateDto);
+        return ResponseEntity.ok(updatedStore);
+    }
+
+
+    /**
+     * 가게 삭제 (MASTER)
+     */
+    @DeleteMapping("/v1/stores/{storeId}")
+    public ResponseEntity<Void> deleteStore(@PathVariable UUID storeId) {
+        storeService.deleteStore(storeId);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    /**
+     * 삭제된 가게 조회 (is_delete = Ture)
+     * */
+    @GetMapping("/v1/stores/deleted")
+    public ResponseEntity<List<Store>> getDeletedStores() {
+        List<Store> deletedStores = storeService.getDeletedStores();
+        return ResponseEntity.ok(deletedStores);
+    }
+    /**
+     * 카테고리별 가게 조회 (ALL)
+     */
+    @GetMapping("/v1/stores/category")
+    public ResponseEntity<List<StoreResDto>> getStoresByCategory(@RequestParam String category) {
+        List<StoreResDto> result = storeService.getStoresByCategory(category);
+        return ResponseEntity.ok(result);
+    }
+    /**
+     * 가게 이름으로 검색 (ALL)
+     */
+    @GetMapping("/v1/stores/search")
+    public ResponseEntity<List<StoreResDto>> searchStoresByName(@RequestParam String keyword) {
+        List<StoreResDto> result = storeService.searchStoresByName(keyword);
+        return ResponseEntity.ok(result);
+    }
+    /**
+     * 가게 상태 변경 (ADMIN, MASTER, OWNER)
+     */
+    @PatchMapping("/owner/v1/stores/{storeId}/status")
+    public ResponseEntity<StoreResDto> updateStoreStatus(@PathVariable UUID storeId,
+                                                         @RequestBody Map<String, String> requestBody) {
+        String statusStr = requestBody.get("isOpen");
+        StoreResDto updatedStore = storeService.updateStoreStatus(storeId, statusStr);
+        return ResponseEntity.ok(updatedStore);
+    }
+
+    /**
+     * 가게 카테고리 변경 (ADMIN, MASTER, OWNER)
+     */
+    @PatchMapping("/owner/v1/stores/{storeId}/category")
+    public ResponseEntity<StoreResDto> updateStoreCategory(@PathVariable UUID storeId,
+                                                           @RequestBody Map<String, String> requestBody) {
+        String categoryStr = requestBody.get("category");
+        StoreResDto updatedStore = storeService.updateStoreCategory(storeId, categoryStr);
+        return ResponseEntity.ok(updatedStore);
+    }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/business/i4_be/domain/store/dto/StoreListResDto.java
+++ b/src/main/java/com/business/i4_be/domain/store/dto/StoreListResDto.java
@@ -1,0 +1,20 @@
+package com.business.i4_be.domain.store.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class StoreListResDto {
+    private final int totalCount;
+    private final List<StoreResDto> stores;
+
+    public StoreListResDto(int totalCount, List<StoreResDto> stores) {
+        this.totalCount = totalCount;
+        this.stores = stores;
+    }
+
+    public static StoreListResDto fromEntityList(List<StoreResDto> storeDtos) {
+        return new StoreListResDto(storeDtos.size(), storeDtos);
+    }
+}

--- a/src/main/java/com/business/i4_be/domain/store/dto/StoreReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/store/dto/StoreReqDto.java
@@ -1,0 +1,79 @@
+package com.business.i4_be.domain.store.dto;
+
+import com.business.i4_be.domain.store.constant.StoreCategory;
+import com.business.i4_be.domain.store.constant.StoreIsOpen;
+import com.business.i4_be.domain.store.entity.Store;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class StoreReqDto {
+
+    @NotBlank(message = "가게 이름은 필수입니다.")
+    private String storeName;
+
+    @NotBlank(message = "가게 전화번호는 필수입니다.")
+    @Pattern(
+            regexp = "^(\\d{2,3})-(\\d{3,4})-(\\d{4})$",
+            message = "전화번호 형식이 올바르지 않습니다. (예: 02-1234-5678 또는 010-1234-5678)"
+    )
+    private String storeNumber;
+
+    @NotBlank(message = "가게 주소는 필수입니다.")
+    private String storeAddress;
+
+    private String storeDetail;
+
+    @NotBlank(message = "오픈 시간은 필수입니다.")
+    private String openTime;
+
+    @NotBlank(message = "닫는 시간은 필수입니다.")
+    private String closedTime;
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    private StoreCategory category;
+
+    @NotNull(message = "오픈여부는 필수입니다.")
+    private StoreIsOpen isOpen;
+
+    @Builder
+    public StoreReqDto(String storeName, String storeNumber, String storeAddress,
+                           String storeDetail, String openTime, String closedTime, StoreCategory category, StoreIsOpen isOpen) {
+        this.storeName = storeName;
+        this.storeNumber = storeNumber;
+        this.storeAddress = storeAddress;
+        this.storeDetail = storeDetail;
+        this.openTime = openTime;
+        this.closedTime = closedTime;
+        this.category = category;
+        this.isOpen= isOpen;
+    }
+    public LocalTime getOpenTimeAsLocalTime() {
+        return LocalTime.parse(this.openTime);
+    }
+
+    public LocalTime getClosedTimeAsLocalTime() {
+        return LocalTime.parse(this.closedTime);
+    }
+    //Entity 변환 메소드
+    public Store toEntity() {
+        return Store.builder()
+                .storeName(this.storeName)
+                .storeNumber(this.storeNumber)
+                .storeAddress(this.storeAddress)
+                .storeDetail(this.storeDetail)
+                .openTime(this.getOpenTimeAsLocalTime())
+                .closedTime(this.getClosedTimeAsLocalTime())
+                .category(this.category)
+                .isOpen(this.isOpen)
+                .build();
+    }
+
+}

--- a/src/main/java/com/business/i4_be/domain/store/dto/StoreResDto.java
+++ b/src/main/java/com/business/i4_be/domain/store/dto/StoreResDto.java
@@ -40,9 +40,7 @@ public class StoreResDto {
         this.isOpen = isOpen;
     }
 
-    /**
-     *  Store 엔티티를 StoreResDto로 변환하는 정적 메서드
-     */
+
     public static StoreResDto fromEntity(Store store) {
         return StoreResDto.builder()
                 .storeId(store.getStoreId())
@@ -57,9 +55,7 @@ public class StoreResDto {
                 .build();
     }
 
-    /**
-     * Store 엔티티 리스트를 StoreResDto 리스트로 변환하는 정적 메서드
-     */
+
     public static List<StoreResDto> fromEntityList(List<Store> stores) {
         return stores.stream()
                 .map(StoreResDto::fromEntity)

--- a/src/main/java/com/business/i4_be/domain/store/dto/StoreResDto.java
+++ b/src/main/java/com/business/i4_be/domain/store/dto/StoreResDto.java
@@ -1,0 +1,68 @@
+package com.business.i4_be.domain.store.dto;
+
+import com.business.i4_be.domain.store.constant.StoreCategory;
+import com.business.i4_be.domain.store.constant.StoreIsOpen;
+import com.business.i4_be.domain.store.entity.Store;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+public class StoreResDto {
+
+    private UUID storeId;
+    private String storeName;
+    private String storeNumber;
+    private String storeAddress;
+    private String storeDetail;
+    private String openTime;
+    private String closedTime;
+    private StoreCategory category;
+    private StoreIsOpen isOpen;
+
+    @Builder
+    public StoreResDto(UUID storeId, String storeName, String storeNumber, String storeAddress,
+                       String storeDetail, String openTime, String closedTime,
+                       StoreCategory category, StoreIsOpen isOpen) {
+        this.storeId = storeId;
+        this.storeName = storeName;
+        this.storeNumber = storeNumber;
+        this.storeAddress = storeAddress;
+        this.storeDetail = storeDetail;
+        this.openTime = openTime;
+        this.closedTime = closedTime;
+        this.category = category;
+        this.isOpen = isOpen;
+    }
+
+    /**
+     *  Store 엔티티를 StoreResDto로 변환하는 정적 메서드
+     */
+    public static StoreResDto fromEntity(Store store) {
+        return StoreResDto.builder()
+                .storeId(store.getStoreId())
+                .storeName(store.getStoreName())
+                .storeNumber(store.getStoreNumber())
+                .storeAddress(store.getStoreAddress())
+                .storeDetail(store.getStoreDetail())
+                .openTime(store.getOpenTime().toString())
+                .closedTime(store.getClosedTime().toString())
+                .category(store.getCategory())
+                .isOpen(store.getIsOpen())
+                .build();
+    }
+
+    /**
+     * Store 엔티티 리스트를 StoreResDto 리스트로 변환하는 정적 메서드
+     */
+    public static List<StoreResDto> fromEntityList(List<Store> stores) {
+        return stores.stream()
+                .map(StoreResDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/business/i4_be/domain/store/dto/StoreUpdateReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/store/dto/StoreUpdateReqDto.java
@@ -1,0 +1,74 @@
+package com.business.i4_be.domain.store.dto;
+
+import com.business.i4_be.domain.store.constant.StoreCategory;
+import com.business.i4_be.domain.store.constant.StoreIsOpen;
+import com.business.i4_be.domain.store.entity.Store;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class StoreUpdateReqDto {
+
+    @NotBlank(message = "가게 전화번호는 필수입니다.")
+    @Pattern(
+            regexp = "^(\\d{2,3})-(\\d{3,4})-(\\d{4})$",
+            message = "전화번호 형식이 올바르지 않습니다. (예: 02-1234-5678 또는 010-1234-5678)"
+    )
+    private String storeNumber;
+
+    @NotBlank(message = "가게 주소는 필수입니다.")
+    private String storeAddress;
+
+    private String storeDetail;
+
+    @NotBlank(message = "오픈 시간은 필수입니다.")
+    private String openTime;
+
+    @NotBlank(message = "닫는 시간은 필수입니다.")
+    private String closedTime;
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    private StoreCategory category;
+
+    @NotNull(message = "오픈여부는 필수입니다.")
+    private StoreIsOpen isOpen;
+
+    @Builder
+    public StoreUpdateReqDto(String storeNumber, String storeAddress, String storeDetail,
+                             String openTime, String closedTime, StoreCategory category, StoreIsOpen isOpen) {
+        this.storeNumber = storeNumber;
+        this.storeAddress = storeAddress;
+        this.storeDetail = storeDetail;
+        this.openTime = openTime;
+        this.closedTime = closedTime;
+        this.category = category;
+        this.isOpen = isOpen;
+    }
+
+    public LocalTime getOpenTimeAsLocalTime() {
+        return LocalTime.parse(this.openTime);
+    }
+
+    public LocalTime getClosedTimeAsLocalTime() {
+        return LocalTime.parse(this.closedTime);
+    }
+    public void applyTo(Store store) {
+        store.updateStoreInfo(
+                this.getStoreNumber(),
+                this.getStoreAddress(),
+                this.getStoreDetail(),
+                this.getOpenTimeAsLocalTime(),
+                this.getClosedTimeAsLocalTime(),
+                this.getCategory(),
+                this.getIsOpen()
+        );
+    }
+
+}

--- a/src/main/java/com/business/i4_be/domain/store/dto/StoreUpdateReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/store/dto/StoreUpdateReqDto.java
@@ -9,10 +9,12 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalTime;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class StoreUpdateReqDto {
 
@@ -59,6 +61,7 @@ public class StoreUpdateReqDto {
     public LocalTime getClosedTimeAsLocalTime() {
         return LocalTime.parse(this.closedTime);
     }
+
     public void applyTo(Store store) {
         store.updateStoreInfo(
                 this.getStoreNumber(),

--- a/src/main/java/com/business/i4_be/domain/store/entity/Store.java
+++ b/src/main/java/com/business/i4_be/domain/store/entity/Store.java
@@ -23,23 +23,24 @@ public class Store extends BaseEntity {
 //
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid", nullable = false, updatable = false)
     private UUID storeId;
 
     @Column(name = "store_name", nullable = false, length = 255)
     private String storeName;
 
-    @NotBlank(message = "가게 주소는 필수입니다.")
+
     @Column(name = "store_address", nullable = false, length = 255)
     private String storeAddress;
 
     @Column(name = "store_detail", columnDefinition = "TEXT")
     private String storeDetail;
 
-    @NotNull(message = "오픈 시간은 필수입니다.")
+
     @Column(name = "open_time", nullable = false)
     private LocalTime openTime;
 
-    @NotNull(message = "닫는 시간은 필수입니다.")
+
     @Column(name = "closed_time", nullable = false)
     private LocalTime closedTime;
 

--- a/src/main/java/com/business/i4_be/domain/store/entity/Store.java
+++ b/src/main/java/com/business/i4_be/domain/store/entity/Store.java
@@ -1,12 +1,13 @@
 package com.business.i4_be.domain.store.entity;
 
+import com.business.i4_be.domain.order.entity.Order;
 import com.business.i4_be.domain.review.entity.Review;
 import com.business.i4_be.domain.store.constant.StoreCategory;
 import com.business.i4_be.domain.store.constant.StoreIsOpen;
 import com.business.i4_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -19,8 +20,9 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 @Table(name = "p_stores")
+@SQLRestriction("deleted_at IS NULL")
 public class Store extends BaseEntity {
-//
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "uuid", nullable = false, updatable = false)
@@ -56,11 +58,11 @@ public class Store extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "is_open", nullable = false)
     private StoreIsOpen isOpen;
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
-
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Order> orders = new ArrayList<>();
 
 
     public void updateStoreInfo(String storeNumber, String storeAddress, String storeDetail,
@@ -76,9 +78,7 @@ public class Store extends BaseEntity {
     }
 
     // 도메인 메서드
-    public void softDelete() {
-        this.isDeleted = true;
-    }
+
     public void updateStatus(StoreIsOpen newStatus) {
         this.isOpen = newStatus;
     }

--- a/src/main/java/com/business/i4_be/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/business/i4_be/domain/store/repository/StoreRepository.java
@@ -6,24 +6,20 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface StoreRepository extends JpaRepository<Store, UUID> {
 
-    Optional<Store> findByStoreIdAndIsDeletedFalse(UUID storeId);
+    List<Store> findAll();
 
-    List<Store> findAllByIsDeletedFalse(); //삭제되지 않은 데이터 조회(기본 조회)
-
-    List<Store> findByStoreNameContaining(String keyword);
     List<Store> findByCategory(StoreCategory category);
 
-    // 검색 기능 (삭제되지 않은 데이터만)
-    List<Store> findByStoreNameContainingAndIsDeletedFalse(String keyword);
-    List<Store> findByCategoryAndIsDeletedFalse(StoreCategory category);
 
-    List<Store> findAllByIsDeletedTrue();
+
+    List<Store> findByStoreNameContaining(String keyword);
+
 
     boolean existsByStoreName(String storeName);
+
 }

--- a/src/main/java/com/business/i4_be/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/business/i4_be/domain/store/repository/StoreRepository.java
@@ -1,0 +1,29 @@
+package com.business.i4_be.domain.store.repository;
+
+import com.business.i4_be.domain.store.constant.StoreCategory;
+import com.business.i4_be.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, UUID> {
+
+    Optional<Store> findByStoreIdAndIsDeletedFalse(UUID storeId);
+
+    List<Store> findAllByIsDeletedFalse(); //삭제되지 않은 데이터 조회(기본 조회)
+
+    List<Store> findByStoreNameContaining(String keyword);
+    List<Store> findByCategory(StoreCategory category);
+
+    // 검색 기능 (삭제되지 않은 데이터만)
+    List<Store> findByStoreNameContainingAndIsDeletedFalse(String keyword);
+    List<Store> findByCategoryAndIsDeletedFalse(StoreCategory category);
+
+    List<Store> findAllByIsDeletedTrue();
+
+    boolean existsByStoreName(String storeName);
+}

--- a/src/main/java/com/business/i4_be/domain/store/service/StoreService.java
+++ b/src/main/java/com/business/i4_be/domain/store/service/StoreService.java
@@ -1,0 +1,146 @@
+package com.business.i4_be.domain.store.service;
+
+import com.business.i4_be.domain.store.constant.StoreCategory;
+import com.business.i4_be.domain.store.constant.StoreIsOpen;
+import com.business.i4_be.domain.store.dto.StoreReqDto;
+import com.business.i4_be.domain.store.dto.StoreUpdateReqDto;
+import com.business.i4_be.domain.store.dto.StoreListResDto;
+import com.business.i4_be.domain.store.dto.StoreResDto;
+import com.business.i4_be.domain.store.entity.Store;
+import com.business.i4_be.domain.store.repository.StoreRepository;
+import com.business.i4_be.global.exception.CustomException;
+import com.business.i4_be.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+    private final StoreRepository storeRepository;
+
+    /**
+     * 가게 등록
+     */
+    @Transactional
+    public StoreResDto createStore(StoreReqDto reqDto) {
+        if (storeRepository.existsByStoreName(reqDto.getStoreName())) {
+            throw new CustomException(ErrorCode.DUPLICATE_STORE_NAME);
+        }
+
+        Store store = reqDto.toEntity();
+        Store savedStore = storeRepository.save(store);
+        return StoreResDto.fromEntity(savedStore);
+    }
+
+    /**
+     * 개별 가게 조회
+     */
+    public StoreResDto getStoreById(UUID storeId) {
+        Store store = storeRepository.findByStoreIdAndIsDeletedFalse(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        return StoreResDto.fromEntity(store);
+    }
+
+    /**
+     * 가게 목록 조회
+     */
+    public StoreListResDto getAllStores() {
+        List<Store> stores = storeRepository.findAllByIsDeletedFalse();
+        List<StoreResDto> storeDtos = StoreResDto.fromEntityList(stores);
+        return StoreListResDto.fromEntityList(storeDtos);
+    }
+
+    /**
+     * 가게 수정 (가게 이름은 수정 불가)
+     */
+    @Transactional
+    public StoreResDto updateStore(UUID storeId, StoreUpdateReqDto updateDto) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        updateDto.applyTo(store);
+        Store updatedStore = storeRepository.save(store);
+        return StoreResDto.fromEntity(updatedStore);
+    }
+
+    /**
+     * 가게 삭제
+     */
+    @Transactional
+    public void deleteStore(UUID storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        store.softDelete();
+        storeRepository.save(store); // 변경 사항 저장
+    }
+    /**
+     * 삭제된 가게 조회
+     * */
+    public List<Store> getDeletedStores() {
+        return storeRepository.findAllByIsDeletedTrue();
+    }
+
+    /**
+     * 가게 이름 검색
+     */
+    public List<StoreResDto> searchStoresByName(String keyword) {
+        List<Store> stores = storeRepository.findByStoreNameContainingAndIsDeletedFalse(keyword);
+        return StoreResDto.fromEntityList(stores);
+    }
+
+    /**
+     * 카테고리별 가게 조회
+     */
+    public List<StoreResDto> getStoresByCategory(String categoryName) {
+        if (!StoreCategory.isValidCategory(categoryName)) {
+            throw new CustomException(ErrorCode.INVALID_CATEGORY);
+        }
+        StoreCategory category = StoreCategory.valueOf(categoryName.toUpperCase());
+        List<Store> stores = storeRepository.findByCategoryAndIsDeletedFalse(category);
+
+        return StoreResDto.fromEntityList(stores);
+    }
+
+    /**
+     * 가게 상태 변경
+     * statusStr 예시: "OPEN" 또는 "CLOSE"
+     */
+    @Transactional
+    public StoreResDto updateStoreStatus(UUID storeId, String statusStr) {
+        StoreIsOpen newStatus;
+        try {
+            newStatus = StoreIsOpen.valueOf(statusStr.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new CustomException(ErrorCode.INVALID_STORE_STATUS);
+        }
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        // 도메인 메서드 사용: updateStatus
+        store.updateStatus(newStatus);
+        Store updatedStore = storeRepository.save(store);
+        return StoreResDto.fromEntity(updatedStore);
+    }
+
+    /**
+     * 가게 카테고리 변경
+     * categoryStr 예시: "치킨" 또는 "피자"
+     */
+    @Transactional
+    public StoreResDto updateStoreCategory(UUID storeId, String categoryStr) {
+        StoreCategory newCategory;
+        try {
+            newCategory = StoreCategory.valueOf(categoryStr.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new CustomException(ErrorCode.INVALID_STORE_CATEGORY);
+        }
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        // 도메인 메서드 사용: updateCategory
+        store.updateCategory(newCategory);
+        Store updatedStore = storeRepository.save(store);
+        return StoreResDto.fromEntity(updatedStore);
+    }
+}

--- a/src/main/java/com/business/i4_be/domain/store/service/StoreService.java
+++ b/src/main/java/com/business/i4_be/domain/store/service/StoreService.java
@@ -1,5 +1,6 @@
 package com.business.i4_be.domain.store.service;
 
+import com.business.i4_be.domain.order.repository.OrderRepository;
 import com.business.i4_be.domain.store.constant.StoreCategory;
 import com.business.i4_be.domain.store.constant.StoreIsOpen;
 import com.business.i4_be.domain.store.dto.StoreReqDto;
@@ -19,12 +20,11 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StoreService {
     private final StoreRepository storeRepository;
 
-    /**
-     * 가게 등록
-     */
+    //가게 등록
     @Transactional
     public StoreResDto createStore(StoreReqDto reqDto) {
         if (storeRepository.existsByStoreName(reqDto.getStoreName())) {
@@ -36,109 +36,95 @@ public class StoreService {
         return StoreResDto.fromEntity(savedStore);
     }
 
-    /**
-     * 개별 가게 조회
-     */
-    public StoreResDto getStoreById(UUID storeId) {
-        Store store = storeRepository.findByStoreIdAndIsDeletedFalse(storeId)
+    //가게 조회(단건)
+    public StoreResDto getStore(UUID storeId) {
+        Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
         return StoreResDto.fromEntity(store);
     }
 
-    /**
-     * 가게 목록 조회
-     */
+    //가게 조회(목록)
     public StoreListResDto getAllStores() {
-        List<Store> stores = storeRepository.findAllByIsDeletedFalse();
+        List<Store> stores = storeRepository.findAll();
         List<StoreResDto> storeDtos = StoreResDto.fromEntityList(stores);
         return StoreListResDto.fromEntityList(storeDtos);
     }
 
-    /**
-     * 가게 수정 (가게 이름은 수정 불가)
-     */
+    //가게 수정
     @Transactional
-    public StoreResDto updateStore(UUID storeId, StoreUpdateReqDto updateDto) {
+    public StoreResDto updateStore(UUID storeId, StoreUpdateReqDto updateReqDto) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
-        updateDto.applyTo(store);
+        if(store.isDeleted()){
+            throw new CustomException(ErrorCode.STORE_ALREADY_DELETED);
+        }
+        updateReqDto.applyTo(store);
         Store updatedStore = storeRepository.save(store);
         return StoreResDto.fromEntity(updatedStore);
     }
 
-    /**
-     * 가게 삭제
-     */
+    //가게 삭제
     @Transactional
     public void deleteStore(UUID storeId) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
-        store.softDelete();
-        storeRepository.save(store); // 변경 사항 저장
-    }
-    /**
-     * 삭제된 가게 조회
-     * */
-    public List<Store> getDeletedStores() {
-        return storeRepository.findAllByIsDeletedTrue();
+        if (store.isDeleted()) {
+            throw new CustomException(ErrorCode.STORE_ALREADY_DELETED);
+        }
+        store.delete("test_user");
+        storeRepository.save(store);
     }
 
-    /**
-     * 가게 이름 검색
-     */
+    //가게 검색(이름)
     public List<StoreResDto> searchStoresByName(String keyword) {
-        List<Store> stores = storeRepository.findByStoreNameContainingAndIsDeletedFalse(keyword);
+        List<Store> stores = storeRepository.findByStoreNameContaining(keyword);
         return StoreResDto.fromEntityList(stores);
     }
 
-    /**
-     * 카테고리별 가게 조회
-     */
+    //가게 검색(카테고리)
     public List<StoreResDto> getStoresByCategory(String categoryName) {
         if (!StoreCategory.isValidCategory(categoryName)) {
             throw new CustomException(ErrorCode.INVALID_CATEGORY);
         }
         StoreCategory category = StoreCategory.valueOf(categoryName.toUpperCase());
-        List<Store> stores = storeRepository.findByCategoryAndIsDeletedFalse(category);
+        List<Store> stores = storeRepository.findByCategory(category);
 
         return StoreResDto.fromEntityList(stores);
     }
 
-    /**
-     * 가게 상태 변경
-     * statusStr 예시: "OPEN" 또는 "CLOSE"
-     */
+    //가게 수정(상태만)
     @Transactional
-    public StoreResDto updateStoreStatus(UUID storeId, String statusStr) {
+    public StoreResDto updateStoreStatus(UUID storeId, String isOpen) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        if (store.isDeleted()) {
+            throw new CustomException(ErrorCode.STORE_ALREADY_DELETED);
+        }
         StoreIsOpen newStatus;
         try {
-            newStatus = StoreIsOpen.valueOf(statusStr.toUpperCase());
+            newStatus = StoreIsOpen.valueOf(isOpen.toUpperCase());
         } catch (IllegalArgumentException | NullPointerException e) {
             throw new CustomException(ErrorCode.INVALID_STORE_STATUS);
         }
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
-        // 도메인 메서드 사용: updateStatus
         store.updateStatus(newStatus);
         Store updatedStore = storeRepository.save(store);
         return StoreResDto.fromEntity(updatedStore);
     }
 
-    /**
-     * 가게 카테고리 변경
-     * categoryStr 예시: "치킨" 또는 "피자"
-     */
+    //가게 수정(카테고리만)
     @Transactional
-    public StoreResDto updateStoreCategory(UUID storeId, String categoryStr) {
+    public StoreResDto updateStoreCategory(UUID storeId, String category) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        if (store.isDeleted()) {
+            throw new CustomException(ErrorCode.STORE_ALREADY_DELETED);
+        }
         StoreCategory newCategory;
         try {
-            newCategory = StoreCategory.valueOf(categoryStr.toUpperCase());
+            newCategory = StoreCategory.valueOf(category.toUpperCase());
         } catch (IllegalArgumentException | NullPointerException e) {
             throw new CustomException(ErrorCode.INVALID_STORE_CATEGORY);
         }
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
-        // 도메인 메서드 사용: updateCategory
         store.updateCategory(newCategory);
         Store updatedStore = storeRepository.save(store);
         return StoreResDto.fromEntity(updatedStore);

--- a/src/main/java/com/business/i4_be/global/entity/BaseEntity.java
+++ b/src/main/java/com/business/i4_be/global/entity/BaseEntity.java
@@ -14,7 +14,6 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/business/i4_be/global/entity/BaseEntity.java
+++ b/src/main/java/com/business/i4_be/global/entity/BaseEntity.java
@@ -40,6 +40,15 @@ public abstract class BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @Column(name = "deleted_by", length = 255)
+    @Column(name = "deleted_by", nullable = true, length = 255)
     private String deletedBy;
+
+    public void delete(String deletedBy) { //
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null; //삭제 여부
+    }
 }

--- a/src/main/java/com/business/i4_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/business/i4_be/global/exception/ErrorCode.java
@@ -15,11 +15,24 @@ public enum ErrorCode {
    * Bean Validation 같은 공통 예외는 0
    */
   USER_NOT_FOUND(1000, NOT_FOUND.value(), "유저가 존재하지 않습니다."),
+
+  /** Store : 2000
+   * */
   STORE_NOT_FOUND(2000, NOT_FOUND.value(), "가게가 존재하지 않습니다."),
   INVALID_STORE_STATUS(2000, BAD_REQUEST.value(), "올바르지 않은 가게 상태입니다."),
   INVALID_STORE_CATEGORY(2000, BAD_REQUEST.value(), "올바르지 않은 카테고리입니다." ),
   INVALID_CATEGORY(2000, BAD_REQUEST.value(), "유효하지 않은 카테고리입니다." ),
-  DUPLICATE_STORE_NAME(2000, BAD_REQUEST.value(), "이미 존재하는 가게 이름입니다." );
+  DUPLICATE_STORE_NAME(2000, BAD_REQUEST.value(), "이미 존재하는 가게 이름입니다." ),
+  STORE_ALREADY_DELETED(2000, NOT_FOUND.value(),"이미 삭제된 가게입니다." ),
+
+
+  ORDER_NOT_COMPLETED(4000, BAD_REQUEST.value(),"완료되지 않은 주문입니다." ),
+
+
+  /**
+   * Review : 5000번
+   * */
+  REVIEW_NOT_FOUND(5000, NOT_FOUND.value(), "존재하지 않는 리뷰입니다." );
 
 
   private final int code; // 도메인 관리 코드

--- a/src/main/java/com/business/i4_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/business/i4_be/global/exception/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.business.i4_be.global.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.Getter;
@@ -13,7 +14,13 @@ public enum ErrorCode {
    * domain 별로 코드 관리
    * Bean Validation 같은 공통 예외는 0
    */
-  USER_NOT_FOUND(1000, NOT_FOUND.value(), "유저가 존재하지 않습니다.");
+  USER_NOT_FOUND(1000, NOT_FOUND.value(), "유저가 존재하지 않습니다."),
+  STORE_NOT_FOUND(2000, NOT_FOUND.value(), "가게가 존재하지 않습니다."),
+  INVALID_STORE_STATUS(2000, BAD_REQUEST.value(), "올바르지 않은 가게 상태입니다."),
+  INVALID_STORE_CATEGORY(2000, BAD_REQUEST.value(), "올바르지 않은 카테고리입니다." ),
+  INVALID_CATEGORY(2000, BAD_REQUEST.value(), "유효하지 않은 카테고리입니다." ),
+  DUPLICATE_STORE_NAME(2000, BAD_REQUEST.value(), "이미 존재하는 가게 이름입니다." );
+
 
   private final int code; // 도메인 관리 코드
   private final int status;


### PR DESCRIPTION
### 📌 작업 내용
이 PR에서 추가된 기능 또는 수정 사항에 대해 간략히 설명해주세요.
- As-is
  - (변경 전 설명을 여기에 작성)
- To-be
  - 가게 등록 
  - 가게 조회 (단건, 전체)
  - 수정 
  - 삭제(softdelete 적용) : 인증이 없는 상태라 deleted_by = test_user 
  - 검색(이름별, 카테고리별)
  - 일부 수정(상태만, 카테고리만)
  - 전부 유저 정보 없이 진행한 거라 리팩토링 예정
  - baseEntity에 softdelete 관련 메서드 추가
  - ERROR 코드 추가 (store : 2000번,  리뷰 : 5000번)
  -
### 🧑‍💻 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 설정 변경
- [ ] CI/CD 변경

### 📷 관련 이미지
해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### 🚨 주의 사항
아직 인증 관련 없어서 baseEntity의 deleteby를 String으로 받아오게 해뒀습니다. 추후에 인증 완료되면 수정하겠습니다.

### 🤔 토론
softdelete는 각 엔티티에서 @SQLRestriction("deleted_at IS NULL")을 추가하면 repository.findAll()을 했을 때 삭제 날짜가 없는 것만 자동으로 나옵니다. 하지만 삭제 처리를한 데이터만 조회하는 기능을 만드려고 했을 때 Repository에서 @Query를 따로 작성했음해도 @SQLRestricion이 더 강력해서 아직 해결 방안을 찾지 못했습니다! 
