### PR TITLE
feat : Cart CURD 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ repositories {
 }
 
 dependencies {
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/business/i4_be/domain/cart/controller/CartController.java
+++ b/src/main/java/com/business/i4_be/domain/cart/controller/CartController.java
@@ -4,10 +4,12 @@ import com.business.i4_be.domain.cart.dto.AddCartReqDto;
 import com.business.i4_be.domain.cart.dto.CartResDto;
 import com.business.i4_be.domain.cart.dto.UpdateCartReqDto;
 import com.business.i4_be.domain.cart.service.CartService;
+import com.business.i4_be.domain.user.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,7 +17,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,33 +28,34 @@ public class CartController {
 
   @PostMapping
   public ResponseEntity<CartResDto> addCart(
-      @RequestParam("userId") Long userId, // 추후 변경
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
       @Valid @RequestBody AddCartReqDto requestDto) {
-    return ResponseEntity.ok(cartService.addCart(userId, requestDto));
+    return ResponseEntity.ok(cartService.addCart(userDetails.getUser().getId(), requestDto));
   }
 
   @GetMapping("/{cartId}")
   public ResponseEntity<CartResDto> getCart(
       @PathVariable("cartId") UUID cartId,
-      @RequestParam("userId") Long userId
+      @AuthenticationPrincipal UserDetailsImpl userDetails
   ) {
-    return ResponseEntity.ok(cartService.getCart(userId, cartId));
+    return ResponseEntity.ok(cartService.getCart(userDetails.getUser().getId(), cartId));
   }
 
   @PutMapping("/{cartId}")
   public ResponseEntity<CartResDto> updateCart(
       @PathVariable("cartId") UUID cartId,
-      @RequestParam("userId") Long userId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
       @Valid @RequestBody UpdateCartReqDto requestDto
   ) {
-    return ResponseEntity.ok(cartService.updateCart(userId, cartId, requestDto));
+    return ResponseEntity.ok(cartService.updateCart(userDetails.getUser().getId(), cartId, requestDto));
   }
 
   @DeleteMapping("/{cartId}")
   public ResponseEntity<Void> deleteCart(
       @PathVariable("cartId") UUID cartId,
-      @RequestParam("userId") Long userId
+      @AuthenticationPrincipal UserDetailsImpl userDetails
   ) {
-    return ResponseEntity.ok(cartService.deleteCart(userId, cartId));
+    cartService.deleteCart(userDetails.getUser().getId(), cartId);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/business/i4_be/domain/cart/dto/AddCartReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/cart/dto/AddCartReqDto.java
@@ -1,7 +1,6 @@
 package com.business.i4_be.domain.cart.dto;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.UUID;
@@ -22,9 +21,5 @@ public class AddCartReqDto {
 
     @Positive(message = "수량은 1개 이상 선택해야 합니다.")
     private Integer quantity;
-
-    @NotNull(message = "가격은 최소 100원 이상이어야 합니다.")
-    @Min(value = 100, message = "가격은 최소 100원 이상이어야 합니다.")
-    private Integer price;
   }
 }

--- a/src/main/java/com/business/i4_be/domain/cart/dto/CartResDto.java
+++ b/src/main/java/com/business/i4_be/domain/cart/dto/CartResDto.java
@@ -1,5 +1,6 @@
 package com.business.i4_be.domain.cart.dto;
 
+import com.business.i4_be.domain.cart.entity.Cart;
 import com.business.i4_be.domain.cart.entity.ProductCart;
 import java.util.List;
 import java.util.UUID;
@@ -18,6 +19,7 @@ public class CartResDto {
   private Long userId;
   private UUID cartId;
   private List<Product> products;
+  private Integer totalPrice;
 
   @Getter
   @Builder
@@ -41,14 +43,15 @@ public class CartResDto {
     }
   }
 
-  public static CartResDto from(Long userId, UUID cartId, List<ProductCart> productCarts) {
-    List<Product> addProducts = productCarts.stream()
+  public static CartResDto from(Long userId, Cart cart) {
+    List<Product> addProducts = cart.getProductCarts().stream()
         .map(Product::from).toList();
 
     return CartResDto.builder()
         .userId(userId)
-        .cartId(cartId)
+        .cartId(cart.getCartId())
         .products(addProducts)
+        .totalPrice(cart.getTotalPrice())
         .build();
   }
 }

--- a/src/main/java/com/business/i4_be/domain/cart/dto/UpdateCartReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/cart/dto/UpdateCartReqDto.java
@@ -1,7 +1,6 @@
 package com.business.i4_be.domain.cart.dto;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
@@ -15,18 +14,17 @@ public class UpdateCartReqDto {
   private UUID storeId;
 
   @Valid
-  private List<Product> products;
+  private List<ProductDto> products;
 
   @Getter
-  public static class Product {
+  public static class ProductDto {
+
     @NotNull
     private UUID productId;
 
     @Positive(message = "수량은 1개 이상 선택해야 합니다.")
     private Integer quantity;
 
-    @NotNull(message = "가격은 최소 100원 이상이어야 합니다.")
-    @Min(value = 100, message = "가격은 최소 100원 이상이어야 합니다.")
-    private Integer price;
   }
 }
+

--- a/src/main/java/com/business/i4_be/domain/cart/entity/Cart.java
+++ b/src/main/java/com/business/i4_be/domain/cart/entity/Cart.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -36,9 +37,21 @@ public class Cart extends BaseEntity {
   @Column(nullable = false)
   private Integer totalPrice;
 
+  private UUID storeId;
+
   @OneToOne
+  @JoinColumn(name = "user_id")
   private User user;
 
-  @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "cart")
-  private List<ProductCart> productCarts = new ArrayList<>();
+  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "cart")
+  @Builder.Default private List<ProductCart> productCarts = new ArrayList<>();
+
+  public Integer updateTotalPrice(Integer price) {
+    this.totalPrice += price;
+    return totalPrice;
+  }
+
+  public void updateStoreId(UUID storeId) {
+    this.storeId = storeId;
+  }
 }

--- a/src/main/java/com/business/i4_be/domain/cart/entity/ProductCart.java
+++ b/src/main/java/com/business/i4_be/domain/cart/entity/ProductCart.java
@@ -49,4 +49,14 @@ public class ProductCart extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "cart_id")
   private Cart cart;
+
+  public Integer updateQuantity(Integer quantity) {
+    this.quantity += quantity;
+    return this.quantity;
+  }
+
+  public Integer updatePrice(Integer price) {
+    this.price = price;
+    return this.price;
+  }
 }

--- a/src/main/java/com/business/i4_be/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/business/i4_be/domain/cart/repository/CartRepository.java
@@ -1,10 +1,16 @@
 package com.business.i4_be.domain.cart.repository;
 
 import com.business.i4_be.domain.cart.entity.Cart;
+import com.business.i4_be.domain.user.entity.User;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CartRepository extends JpaRepository<Cart, UUID> {
+
+  Cart findByUser(User user);
+
+  Cart findByCartIdAndUserId(UUID cartId, Long userId);
+
 }

--- a/src/main/java/com/business/i4_be/domain/cart/service/CartService.java
+++ b/src/main/java/com/business/i4_be/domain/cart/service/CartService.java
@@ -1,34 +1,169 @@
 package com.business.i4_be.domain.cart.service;
 
+import static com.business.i4_be.global.exception.ErrorCode.ALREADY_DIFFERENT_STORE_PRODUCT;
+import static com.business.i4_be.global.exception.ErrorCode.NOT_ENOUGH_QUANTITY;
+import static com.business.i4_be.global.exception.ErrorCode.PRODUCT_NOT_FOUND;
+import static com.business.i4_be.global.exception.ErrorCode.USER_NOT_FOUND;
+
 import com.business.i4_be.domain.cart.dto.AddCartReqDto;
 import com.business.i4_be.domain.cart.dto.CartResDto;
 import com.business.i4_be.domain.cart.dto.UpdateCartReqDto;
+import com.business.i4_be.domain.cart.dto.UpdateCartReqDto.ProductDto;
+import com.business.i4_be.domain.cart.entity.Cart;
+import com.business.i4_be.domain.cart.entity.ProductCart;
 import com.business.i4_be.domain.cart.repository.CartRepository;
-import com.business.i4_be.domain.cart.repository.ProductCartRepository;
+import com.business.i4_be.domain.product.entity.Product;
+import com.business.i4_be.domain.product.repository.ProductRepository;
+import com.business.i4_be.domain.user.entity.User;
+import com.business.i4_be.domain.user.repository.UserRepository;
+import com.business.i4_be.global.exception.CustomException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CartService {
 
+  private final UserRepository userRepository;
   private final CartRepository cartRepository;
-  private final ProductCartRepository productCartRepository;
+  private final ProductRepository productRepository;
 
+  @Transactional
   public CartResDto addCart(Long userId, AddCartReqDto requestDto) {
-    return null;
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    Product product = productRepository.findByProductIdAndStore_storeId(
+            requestDto.getProduct().getProductId(), requestDto.getStoreId())
+        .orElseThrow(() -> new CustomException(PRODUCT_NOT_FOUND));
+
+    if (product.getQuantity() < requestDto.getProduct().getQuantity()) {
+      throw new CustomException(NOT_ENOUGH_QUANTITY);
+    }
+
+    Cart cart = getOrDefaultCart(user);
+    if (cart.getStoreId() == null) {
+      cart.updateStoreId(requestDto.getStoreId());
+    } else {
+      if (!requestDto.getStoreId().equals(cart.getStoreId())) {
+        throw new CustomException(ALREADY_DIFFERENT_STORE_PRODUCT);
+      }
+    }
+
+    // 장바구니에 같은 상품이 있나 확인
+    boolean exist = false;
+    if (!cart.getProductCarts().isEmpty()) {
+      for (ProductCart productCart : cart.getProductCarts()) {
+        if (product.getProductName().equals(productCart.getProductName())) {
+          if (productCart.getQuantity() + requestDto.getProduct().getQuantity()
+              > product.getQuantity()) {
+            throw new CustomException(NOT_ENOUGH_QUANTITY);
+          }
+          Integer totalQuantity = productCart.updateQuantity(requestDto.getProduct().getQuantity());
+
+          log.info("특정 상품 총 가격 : {}",totalQuantity * product.getPrice());
+          productCart.updatePrice(totalQuantity * product.getPrice());
+          cart.updateTotalPrice(requestDto.getProduct().getQuantity() * product.getPrice());
+          exist = true;
+          break;
+        }
+      }
+    }
+
+    if (!exist) { // 같은 상품이 없다.
+      ProductCart productCart = ProductCart.builder()
+          .productName(product.getProductName())
+          .quantity(requestDto.getProduct().getQuantity())
+          .price(product.getPrice() * requestDto.getProduct().getQuantity())
+          .image(product.getImage())
+          .product(product)
+          .cart(cart)
+          .build();
+      cart.getProductCarts().add(productCart);
+      cart.updateTotalPrice(productCart.getPrice());
+    }
+
+    cartRepository.save(cart);
+    return CartResDto.from(userId, cart);
   }
 
+
+  @Transactional(readOnly = true)
   public CartResDto getCart(Long userId, UUID cartId) {
-    return null;
+    User user = userRepository.findByUserId(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    Cart cart = getOrDefaultCart(user);
+    return CartResDto.from(userId, cart);
   }
 
+  @Transactional
   public CartResDto updateCart(Long userId, UUID cartId, UpdateCartReqDto requestDto) {
-    return null;
+    User user = userRepository.findByUserId(userId)
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    Cart cart = cartRepository.findByUser(user);
+    if (cart != null) {
+      if (!requestDto.getStoreId().equals(cart.getStoreId())) {
+        throw new CustomException(ALREADY_DIFFERENT_STORE_PRODUCT);
+      }
+      cart.getProductCarts().clear();
+      cart.updateTotalPrice(-cart.getTotalPrice());
+    } else {
+      cart = Cart.builder()
+          .totalPrice(0)
+          .user(user)
+          .build();
+    }
+
+    for (ProductDto product : requestDto.getProducts()) {
+      Product getProduct = productRepository.findByProductId(product.getProductId())
+          .orElseThrow(() -> new CustomException(PRODUCT_NOT_FOUND));
+      if (getProduct.getQuantity() < product.getQuantity()) {
+        throw new CustomException(NOT_ENOUGH_QUANTITY);
+      }
+
+      ProductCart productCart = makeProductCart(product, getProduct,
+          cart);
+      cart.getProductCarts().add(productCart);
+      cart.updateTotalPrice(productCart.getPrice());
+    }
+    cartRepository.save(cart);
+
+    return CartResDto.from(userId, cart);
   }
 
-  public Void deleteCart(Long userId, UUID cartId) {
-    return null;
+  @Transactional
+  public void deleteCart(Long userId, UUID cartId) {
+    Cart cart = cartRepository.findByCartIdAndUserId(cartId, userId);
+    if (cart != null) {
+      cartRepository.delete(cart);
+    }
+  }
+
+  private Cart getOrDefaultCart(User user) {
+    Cart cart = cartRepository.findByUser(user);
+    if (cart == null) {
+      cart = Cart.builder()
+          .totalPrice(0)
+          .user(user)
+          .build();
+    }
+    return cart;
+  }
+
+  private ProductCart makeProductCart(ProductDto product, Product getProduct, Cart cart) {
+    return ProductCart.builder()
+        .productName(getProduct.getProductName())
+        .quantity(product.getQuantity())
+        .price(product.getQuantity() * getProduct.getPrice())
+        .image(getProduct.getImage())
+        .cart(cart)
+        .product(getProduct)
+        .build();
   }
 }

--- a/src/main/java/com/business/i4_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/business/i4_be/global/config/SecurityConfig.java
@@ -43,6 +43,11 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/delete/me").authenticated()
                         .requestMatchers("/api/v1/delete/{userId}").hasAnyAuthority("ROLE_MASTER", "ROLE_ADMIN")
 
+                        // --- 장바구니 ----
+                        .requestMatchers("/api/v1/cart/**").authenticated()
+                        .requestMatchers("/api/v1/cart/**")
+                        .hasAnyAuthority("ROLE_USER", "ROLE_MASTER", "ROLE_ADMIN")
+
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(corsConfig.corsFilter(), UsernamePasswordAuthenticationFilter.class) // CORS 필터

--- a/src/main/java/com/business/i4_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/business/i4_be/global/exception/ErrorCode.java
@@ -1,10 +1,10 @@
 package com.business.i4_be.global.exception;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
@@ -39,7 +39,13 @@ public enum ErrorCode {
    * Product 3000번
    */
   ALREADY_EXIST_PRODUCT(3000, BAD_REQUEST.value(), "이미 존재하는 상품명입니다."),
-  PRODUCT_NOT_FOUND(3000, NOT_FOUND.value(), "상품이 존재하지 않습니다.");
+  PRODUCT_NOT_FOUND(3000, NOT_FOUND.value(), "상품이 존재하지 않습니다."),
+
+  /**
+   * Cart 7000번
+   */
+  NOT_ENOUGH_QUANTITY(7000, BAD_REQUEST.value(), "상품 수량이 부족합니다."),
+  ALREADY_DIFFERENT_STORE_PRODUCT(7000, BAD_REQUEST.value(), "다른 가게 상품이 존재합니다.");
 
   private final int code; // 도메인 관리 코드
   private final int status;


### PR DESCRIPTION
### 📌 작업 내용
이 PR에서 추가된 기능 또는 수정 사항에 대해 간략히 설명해주세요.
- As-is
  - Cart Service가 모두 null 이었습니다.
- To-be
  - Cart 등록, 수정, 조회, 삭제 구현

### 🧑‍💻 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 설정 변경
- [ ] CI/CD 변경

### 📷 관련 이미지
해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### 🚨 주의 사항
- Cart Service에 User 인증을 도입했고, Security Path에 Cart에 대한 변경사항이 있습니다.
- Cart 도메인은 7000번으로 했습니다.
- User는 Cart를 1개만 가질 수 있고, 한 가게에서만 담을 수 있습니다. 다른 가게 상품을 담아야한다면 먼저 장바구니를 비워야합니다. 
- 현재 CartId가 UUID로 존재합니다. 하지만 User의 PK로 CartId를 PK하는게 더 좋아보입니다. User 당 1개라서 CartId 없이 User 정보로 Cart 정보를 전부 가져올 수 있습니다. 이후에 변경 예정입니다. 
- 테스트 코드도 이후에 추가할 예정입니다.
- API 테스트 완료 했습니다.

### 🤔 토론
기능을 추가하면서 생긴 고민을 작성해주세요.
장바구니는 Delete를 호출해서 삭제합니다. 장바구니 History를 남기는 것에 대해 필요가 있나 싶은데 혹시 다른 생각 있으시면 얘기해주세요!