### PR TITLE
feat : Product Update, delete 구현 및 Product service refactor

### DIFF
--- a/src/main/java/com/business/i4_be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/business/i4_be/domain/product/controller/ProductController.java
@@ -9,11 +9,13 @@ import com.business.i4_be.domain.product.dto.ProductsResDto;
 import com.business.i4_be.domain.product.dto.UpdateProductReqDto;
 import com.business.i4_be.domain.product.dto.UpdateProductResDto;
 import com.business.i4_be.domain.product.service.ProductService;
+import com.business.i4_be.domain.user.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,25 +36,30 @@ public class ProductController {
 
   @PostMapping
   public ResponseEntity<AddProductResDto> addProduct(
-      @RequestParam("userId") Long userId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
       @Valid @RequestBody AddProductReqDto requestDto) {
-    return ResponseEntity.status(CREATED).body(productService.addProduct(userId, requestDto));
+    return ResponseEntity.status(CREATED).
+        body(productService.addProduct(userDetails.getUser().getId(), requestDto));
   }
 
   @PutMapping("/{productId}")
   public ResponseEntity<UpdateProductResDto> updateProduct(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
       @PathVariable("productId") UUID productId,
       @Valid @RequestBody UpdateProductReqDto requestDto
   ) {
-    return ResponseEntity.ok().body(productService.updateProduct(productId, requestDto));
+    return ResponseEntity.ok().body(
+        productService.updateProduct(userDetails.getUser().getId(), productId, requestDto));
   }
 
   @DeleteMapping("/{productId}")
   public ResponseEntity<Void> deleteProduct(
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
       @PathVariable("productId") UUID productId,
       @RequestParam("storeId") UUID storeId
   ) {
-    return ResponseEntity.ok().body(productService.deleteProduct(storeId, productId));
+    productService.deleteProduct(userDetails.getUser().getId(), storeId, productId);
+    return ResponseEntity.ok().build();
   }
 
   @GetMapping("/{productId}")

--- a/src/main/java/com/business/i4_be/domain/product/controller/ProductOwnerController.java
+++ b/src/main/java/com/business/i4_be/domain/product/controller/ProductOwnerController.java
@@ -2,9 +2,11 @@ package com.business.i4_be.domain.product.controller;
 
 import com.business.i4_be.domain.product.dto.ProductsResDto;
 import com.business.i4_be.domain.product.service.ProductService;
+import com.business.i4_be.domain.user.security.UserDetailsImpl;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,8 +21,9 @@ public class ProductOwnerController {
 
   @GetMapping
   public ResponseEntity<ProductsResDto> getProducts(
-      @RequestParam("userId") Long userId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails,
       @RequestParam("storeId") UUID storeId) {
-    return ResponseEntity.ok().body(productService.getProducts(storeId));
+    return ResponseEntity.ok().body(
+        productService.getProducts(userDetails.getUser().getId(),storeId));
   }
 }

--- a/src/main/java/com/business/i4_be/domain/product/dto/AddProductReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/AddProductReqDto.java
@@ -2,6 +2,7 @@ package com.business.i4_be.domain.product.dto;
 
 import com.business.i4_be.domain.product.constants.ProductStatus;
 import com.business.i4_be.domain.product.entity.Product;
+import com.business.i4_be.domain.store.entity.Store;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -49,7 +50,7 @@ public class AddProductReqDto {
     private String imageUrl;
   }
 
-  public static Product toEntity(ProductDto productDto) {
+  public static Product toEntity( Store store, ProductDto productDto) {
     return Product.builder()
         .productName(productDto.getProductName())
         .quantity(productDto.getQuantity())
@@ -57,6 +58,7 @@ public class AddProductReqDto {
         .text(productDto.getText())
         .status(productDto.getStatus())
         .image(productDto.getImageUrl())
+        .store(store)
         .build();
   }
 }

--- a/src/main/java/com/business/i4_be/domain/product/dto/AddProductResDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/AddProductResDto.java
@@ -21,7 +21,7 @@ public class AddProductResDto {
   @Builder
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
-  private static class ProductDto {
+  public static class ProductDto {
     private UUID productId;
     private String productName;
     private Integer quantity;

--- a/src/main/java/com/business/i4_be/domain/product/dto/ProductResDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/ProductResDto.java
@@ -23,7 +23,6 @@ public class ProductResDto {
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
   private static class ProductDto {
-
     private UUID productId;
     private String productName;
     private Integer quantity;
@@ -32,8 +31,10 @@ public class ProductResDto {
     private ProductStatus status;
     private String imageUrl;
 
-    public static ProductDto from(Product product) {
-      return ProductDto.builder()
+  }
+
+  public static ProductResDto from(UUID storeId, Product product) {
+    ProductDto productDto = ProductDto.builder()
           .productId(product.getProductId())
           .productName(product.getProductName())
           .quantity(product.getQuantity())
@@ -42,15 +43,10 @@ public class ProductResDto {
           .status(product.getStatus())
           .imageUrl(product.getImage())
           .build();
-    }
-  }
-
-  public static ProductResDto from(UUID storeId, Product product) {
-    ProductDto getProduct = ProductDto.from(product);
 
     return ProductResDto.builder()
         .storeId(storeId)
-        .productDto(getProduct)
+        .productDto(productDto)
         .build();
   }
 }

--- a/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductReqDto.java
@@ -16,10 +16,10 @@ public class UpdateProductReqDto {
   private UUID storeId;
 
   @Valid
-  private Product product;
+  private ProductDto productDto;
 
   @Getter
-  public static class Product {
+  public static class ProductDto {
 
     @NotBlank(message = "상품명은 필수입니다.")
     private String productName;

--- a/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductResDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductResDto.java
@@ -1,6 +1,7 @@
 package com.business.i4_be.domain.product.dto;
 
 import com.business.i4_be.domain.product.constants.ProductStatus;
+import com.business.i4_be.domain.product.entity.Product;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,13 +15,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateProductResDto {
 
-  private Product product;
+  private ProductDto productDto;
 
   @Getter
   @Builder
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
-  private static class Product {
+  public static class ProductDto {
     private UUID productId;
     private String productName;
     private Integer quantity;
@@ -30,8 +31,8 @@ public class UpdateProductResDto {
     private String imageUrl;
   }
 
-  public static UpdateProductResDto from(com.business.i4_be.domain.product.entity.Product product) {
-    UpdateProductResDto.Product updateProduct = UpdateProductResDto.Product.builder()
+  public static UpdateProductResDto from(Product product) {
+    ProductDto updateProduct = ProductDto.builder()
         .productId(product.getProductId())
         .productName(product.getProductName())
         .quantity(product.getQuantity())
@@ -42,7 +43,7 @@ public class UpdateProductResDto {
         .build();
 
     return UpdateProductResDto.builder()
-        .product(updateProduct)
+        .productDto(updateProduct)
         .build();
   }
 }

--- a/src/main/java/com/business/i4_be/domain/product/entity/Product.java
+++ b/src/main/java/com/business/i4_be/domain/product/entity/Product.java
@@ -20,11 +20,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
 @Table(name = "p_products")
 @Builder
+@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Product extends BaseEntity {
@@ -54,4 +56,28 @@ public class Product extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "store_id")
   private Store store;
+
+  public void setProductName(String productName) {
+    this.productName = productName;
+  }
+
+  public void setQuantity(Integer quantity) {
+    this.quantity = quantity;
+  }
+
+  public void setPrice(Integer price) {
+    this.price = price;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  public void setStatus(ProductStatus status) {
+    this.status = status;
+  }
+
+  public void setImage(String image) {
+    this.image = image;
+  }
 }

--- a/src/main/java/com/business/i4_be/domain/product/entity/Product.java
+++ b/src/main/java/com/business/i4_be/domain/product/entity/Product.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,7 +25,9 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
-@Table(name = "p_products")
+@Table(name = "p_products", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"product_name", "deleted_at"})
+})
 @Builder
 @SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,7 +39,7 @@ public class Product extends BaseEntity {
   @Column(columnDefinition = "uuid", nullable = false, updatable = false)
   private UUID productId;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private String productName;
 
   @Column(nullable = false)

--- a/src/main/java/com/business/i4_be/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/business/i4_be/domain/product/repository/ProductRepository.java
@@ -1,6 +1,7 @@
 package com.business.i4_be.domain.product.repository;
 
 import com.business.i4_be.domain.product.entity.Product;
+import com.business.i4_be.domain.store.entity.Store;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -16,7 +17,7 @@ public interface ProductRepository extends JpaRepository<Product, UUID> {
 
   List<Product> findByStore_storeIdAndProductNameContaining(UUID storeId, String keyword);
 
-  List<Product> findByStore_storeId(UUID storeId);
+  List<Product> findByStore(Store store);
 
   boolean existsByProductName(String productName);
 

--- a/src/main/java/com/business/i4_be/domain/product/service/ProductService.java
+++ b/src/main/java/com/business/i4_be/domain/product/service/ProductService.java
@@ -1,6 +1,8 @@
 package com.business.i4_be.domain.product.service;
 
 import static com.business.i4_be.global.exception.ErrorCode.ALREADY_EXIST_PRODUCT;
+import static com.business.i4_be.global.exception.ErrorCode.PRODUCT_NOT_FOUND;
+import static com.business.i4_be.global.exception.ErrorCode.STORE_NOT_FOUND;
 
 import com.business.i4_be.domain.product.dto.AddProductReqDto;
 import com.business.i4_be.domain.product.dto.AddProductResDto;
@@ -10,25 +12,30 @@ import com.business.i4_be.domain.product.dto.UpdateProductReqDto;
 import com.business.i4_be.domain.product.dto.UpdateProductResDto;
 import com.business.i4_be.domain.product.entity.Product;
 import com.business.i4_be.domain.product.repository.ProductRepository;
+import com.business.i4_be.domain.store.entity.Store;
+import com.business.i4_be.domain.store.repository.StoreRepository;
 import com.business.i4_be.global.exception.CustomException;
 import com.business.i4_be.global.exception.ErrorCode;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProductService {
 
   private final ProductRepository productRepository;
+  private final StoreRepository storeRepository;
 
   @Transactional
   public AddProductResDto addProduct(Long userId, AddProductReqDto requestDto)
       throws CustomException {
-
-    // TODO User, Store 검증 필요
+    Store store = storeRepository.findById(requestDto.getStoreId())
+        .orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
 
     boolean exist = productRepository.existsByProductName(
         requestDto.getProductDto().getProductName());
@@ -37,21 +44,29 @@ public class ProductService {
     }
 
     return AddProductResDto.from(
-        productRepository.save(AddProductReqDto.toEntity(requestDto.getProductDto())));
+        productRepository.save(AddProductReqDto.toEntity(store, requestDto.getProductDto())));
   }
 
-  public UpdateProductResDto updateProduct(UUID productId, UpdateProductReqDto requestDto) {
-    return null;
+  @Transactional
+  public UpdateProductResDto updateProduct(Long userId, UUID productId, UpdateProductReqDto requestDto) {
+    Product product = productRepository.findByProductIdAndStore_storeId(productId, requestDto.getStoreId())
+        .orElseThrow(() -> new CustomException(PRODUCT_NOT_FOUND));
+
+    updateProduct(requestDto, product);
+    return UpdateProductResDto.from(product);
   }
 
-  public Void deleteProduct(UUID storeId, UUID productId) {
-    return null;
+  @Transactional
+  public void deleteProduct(Long userId, UUID storeId, UUID productId) {
+    Product product = productRepository.findByProductIdAndStore_storeId(productId, storeId)
+        .orElseThrow(() -> new CustomException(PRODUCT_NOT_FOUND));
+
+    product.delete(String.valueOf(userId));
+    log.info("상품 삭제 요청 : {}", userId);
   }
 
   @Transactional(readOnly = true)
   public ProductResDto getProduct(UUID storeId, UUID productId) {
-
-    // TODO store, user 검증 필요
     Product product = productRepository.findByProductIdAndStore_storeId(productId, storeId)
         .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
@@ -60,15 +75,25 @@ public class ProductService {
 
   @Transactional(readOnly = true)
   public ProductsResDto searchProducts(UUID storeId, String keyword) {
-    // TODO user store 검증 필요
     List<Product> products = productRepository.findByStore_storeIdAndProductNameContaining(storeId, keyword);
     return ProductsResDto.from(storeId, products);
   }
 
   @Transactional(readOnly = true)
-  public ProductsResDto getProducts(UUID storeId) {
-    // TODO user, storeId 검증 필요
-    List<Product> products = productRepository.findByStore_storeId(storeId);
+  public ProductsResDto getProducts(Long userId, UUID storeId) {
+    Store store = storeRepository.findById(storeId)
+        .orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+
+    List<Product> products = productRepository.findByStore(store);
     return ProductsResDto.from(storeId, products);
+  }
+
+  private void updateProduct(UpdateProductReqDto requestDto, Product product) {
+    product.setProductName(requestDto.getProductDto().getProductName());
+    product.setQuantity(requestDto.getProductDto().getQuantity());
+    product.setPrice(requestDto.getProductDto().getPrice());
+    product.setText(requestDto.getProductDto().getText());
+    product.setStatus(requestDto.getProductDto().getStatus());
+    product.setStatus(requestDto.getProductDto().getStatus());
   }
 }

--- a/src/main/java/com/business/i4_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/business/i4_be/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.business.i4_be.global.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -47,6 +48,11 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/cart/**").authenticated()
                         .requestMatchers("/api/v1/cart/**")
                         .hasAnyAuthority("ROLE_USER", "ROLE_MASTER", "ROLE_ADMIN")
+
+                        // Product
+                        .requestMatchers("/api/owner/v1/products").hasAnyAuthority("ROLE_MASTER", "ROLE_ADMIN", "ROLE_OWNER")
+                        .requestMatchers(HttpMethod.GET, "api/v1/products/**","/api/v1/products").permitAll()
+                        .requestMatchers("/api/v1/products/**","/api/v1/products").hasAnyAuthority("ROLE_MASTER", "ROLE_ADMIN", "ROLE_OWNER")
 
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
### 📌 작업 내용
이 PR에서 추가된 기능 또는 수정 사항에 대해 간략히 설명해주세요.
- As-is
  - Product 수정, 삭제 기능 null,
  - User 토큰 인증이 적용되지 않았었습니다.
- To-be
  - Feat : Product 수정, 삭제 기능 추가
  - Refactor : Product 추가, 조회 기능에 대한 User 토큰 인증 적용
  - Dto 클래스의 내부 클래스명 수정 Product -> Product Dto

### 🧑‍💻 작업 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 설정 변경
- [ ] CI/CD 변경

### 📷 관련 이미지
해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### 🚨 주의 사항
리뷰어가 알아야 할 주의 사항이나 필요한 추가 정보가 있다면 작성해주세요.

### 🤔 토론
- soft delete에서 중복 키 문제가 있습니다. unique 컬럼( ex) "A" )을 detele 해놓은 상태에서, 다시 "A"라는 컬럼을 넣을 때 중복키 에러가 발생합니다. API 서비스 로직에서는 deleted_at is Null 옵션 때문에 "A"로 조회를 해도 DB에 존재한다는 예외가 발생하지 않습니다. 하지만 DB에 반영될 때 detete_at이 null이 아닌 레코드도 인식되기 때문에 "A"를 넣을 수 없는 SQL 예외가 발생합니다.
--> 찾아본 결과 괜찮은 해결 방법은 2가지 정도가 있는 것 같습니다. 
- jpa문에 deleted_at 컬럼 옵션 추가 : 조회시 jpa명령어마다 findByIdDeleted_atIsNotNull 이렇게 하는 방법도 있지만 매 호출마다 넣는 것은 효율적이지 않은 것습니다.
- deleted_at 과 "A"가 담긴 컬럼을 동시에 unique 키로 만드는 방법이 있습니다. 그러면 "A"가 담긴 컬럼은 unique를 해제 해야합니다. 이렇게 하면 조회시엔 @SQLRestriction으로 deleted_at이 null인 필드만 조회되서 중복검사를 할 수 있고, 삭제할 땐 deleted_at이 달라지기 때문에 같은 "A"를 넣을 수 있습니다. 

- 아직 둘다 테스트는 안해봤지만 의견이 통합되면 테스트 후 PR에 커밋을 추가하겠습니다! 
