### PR TITLE
test: product - 등록, 수정, 삭제 테스트 코드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 src/main/resources/application.yml
+*.yml

--- a/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductReqDto.java
+++ b/src/main/java/com/business/i4_be/domain/product/dto/UpdateProductReqDto.java
@@ -7,9 +7,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UpdateProductReqDto {
 
   @NotNull
@@ -19,6 +25,9 @@ public class UpdateProductReqDto {
   private ProductDto productDto;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class ProductDto {
 
     @NotBlank(message = "상품명은 필수입니다.")

--- a/src/main/java/com/business/i4_be/domain/product/service/ProductService.java
+++ b/src/main/java/com/business/i4_be/domain/product/service/ProductService.java
@@ -52,7 +52,12 @@ public class ProductService {
     Product product = productRepository.findByProductIdAndStore_storeId(productId, requestDto.getStoreId())
         .orElseThrow(() -> new CustomException(PRODUCT_NOT_FOUND));
 
-    updateProduct(requestDto, product);
+    boolean exist = productRepository.existsByProductName(requestDto.getProductDto().getProductName());
+    if(exist && !product.getProductName().equals(requestDto.getProductDto().getProductName())) {
+      throw new CustomException(ALREADY_EXIST_PRODUCT);
+    }
+
+    updateProductEntity(requestDto, product);
     return UpdateProductResDto.from(product);
   }
 
@@ -88,7 +93,7 @@ public class ProductService {
     return ProductsResDto.from(storeId, products);
   }
 
-  private void updateProduct(UpdateProductReqDto requestDto, Product product) {
+  private void updateProductEntity(UpdateProductReqDto requestDto, Product product) {
     product.setProductName(requestDto.getProductDto().getProductName());
     product.setQuantity(requestDto.getProductDto().getQuantity());
     product.setPrice(requestDto.getProductDto().getPrice());

--- a/src/test/java/com/business/i4_be/common/DeleteSupport.java
+++ b/src/test/java/com/business/i4_be/common/DeleteSupport.java
@@ -1,0 +1,25 @@
+package com.business.i4_be.common;
+
+import com.business.i4_be.config.TearDownExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+
+@Import(TearDownExecutor.class)
+@ActiveProfiles("test")
+@SpringBootTest
+@TestConstructor(autowireMode = AutowireMode.ALL)
+public abstract class DeleteSupport {
+
+  @Autowired
+  TearDownExecutor tearDownExecutor;
+
+  @AfterEach
+  void delete() {
+    tearDownExecutor.execute();
+  }
+}

--- a/src/test/java/com/business/i4_be/config/TearDownExecutor.java
+++ b/src/test/java/com/business/i4_be/config/TearDownExecutor.java
@@ -1,0 +1,59 @@
+package com.business.i4_be.config;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestComponent
+public class TearDownExecutor implements InitializingBean {
+
+  private static final String SCHEMA_NAME = "test.";
+
+  @PersistenceContext
+  private EntityManager entityManager;
+  private List<String> tableNames;
+
+  @Override
+  public void afterPropertiesSet() {
+    tableNames = entityManager.getMetamodel()
+        .getEntities()
+        .stream()
+        .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+        .map(e -> {
+          Table tableAnnotation = e.getJavaType().getAnnotation(Table.class);
+          return (tableAnnotation != null) ? tableAnnotation.name()
+              : convertToLowerUnderscore(e.getName());
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public void execute() {
+    entityManager.flush();
+
+    // 외래키 제약을 비활성화 (모든 테이블에 대해 트리거를 비활성화)
+    tableNames.forEach(tableName ->
+        entityManager.createNativeQuery("ALTER TABLE " + SCHEMA_NAME + tableName + " DISABLE TRIGGER ALL").executeUpdate()
+    );
+
+    // 모든 테이블을 삭제
+    tableNames.forEach(tableName ->
+        entityManager.createNativeQuery("TRUNCATE TABLE " + SCHEMA_NAME + tableName + " RESTART IDENTITY CASCADE").executeUpdate()
+    );
+
+    // 외래키 제약을 다시 활성화 (모든 테이블에 대해 트리거를 활성화)
+    tableNames.forEach(tableName ->
+        entityManager.createNativeQuery("ALTER TABLE " + SCHEMA_NAME + tableName + " ENABLE TRIGGER ALL").executeUpdate()
+    );
+  }
+
+  private String convertToLowerUnderscore(String camelCase) {
+    return camelCase.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
+  }
+}

--- a/src/test/java/com/business/i4_be/domain/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/business/i4_be/domain/product/repository/ProductRepositoryTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -24,7 +23,6 @@ class ProductRepositoryTest {
 
   @Test
   @DisplayName("Product Save 성공")
-  @Rollback(false)
   void product_save() {
     //when
     product = makeProduct();

--- a/src/test/java/com/business/i4_be/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/business/i4_be/domain/product/service/ProductServiceTest.java
@@ -1,24 +1,34 @@
 package com.business.i4_be.domain.product.service;
 
+import static com.business.i4_be.global.exception.ErrorCode.ALREADY_EXIST_PRODUCT;
+import static com.business.i4_be.global.exception.ErrorCode.PRODUCT_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.business.i4_be.common.DeleteSupport;
 import com.business.i4_be.domain.product.constants.ProductStatus;
 import com.business.i4_be.domain.product.dto.AddProductReqDto;
 import com.business.i4_be.domain.product.dto.AddProductReqDto.ProductDto;
+import com.business.i4_be.domain.product.dto.UpdateProductReqDto;
+import com.business.i4_be.domain.product.dto.UpdateProductResDto;
 import com.business.i4_be.domain.product.entity.Product;
 import com.business.i4_be.domain.product.repository.ProductRepository;
+import com.business.i4_be.domain.store.constant.StoreCategory;
+import com.business.i4_be.domain.store.constant.StoreIsOpen;
+import com.business.i4_be.domain.store.entity.Store;
+import com.business.i4_be.domain.store.repository.StoreRepository;
 import com.business.i4_be.global.exception.CustomException;
+import java.time.LocalTime;
 import java.util.Optional;
 import java.util.UUID;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-class ProductServiceTest {
+class ProductServiceTest extends DeleteSupport {
 
   @Autowired
   ProductService productService;
@@ -26,46 +36,109 @@ class ProductServiceTest {
   @Autowired
   ProductRepository productRepository;
 
+  @Autowired
+  StoreRepository storeRepository;
+
+  Store store;
+
+  @BeforeEach
+  void setUp() {
+    Store addStore = makeStore();
+    store = storeRepository.save(addStore);
+  }
+
   @Test
   @DisplayName("상품 등록 성공")
-  @Transactional
   void product_save() {
     // given
     Long userId = 1L;
 
-    AddProductReqDto reqDto = makeAddProductReqDto("치즈 떡볶이", 2, 5500);
+    AddProductReqDto reqDto = makeAddProductReqDto(store.getStoreId(), "치즈 떡볶이", 2, 5500);
 
     // when
     productService.addProduct(userId, reqDto);
 
     //then
-    Optional<Product> addProduct = productRepository.findByProductName(reqDto.getProductDto().getProductName());
+    Optional<Product> addProduct = productRepository.findByProductName(
+        reqDto.getProductDto().getProductName());
 
     assertThat(addProduct.isPresent()).isTrue();
-    assertThat(addProduct.get().getProductName()).isEqualTo(reqDto.getProductDto().getProductName());
+    assertThat(addProduct.get().getProductName()).isEqualTo(
+        reqDto.getProductDto().getProductName());
     assertThat(addProduct.get().getQuantity()).isEqualTo(reqDto.getProductDto().getQuantity());
     assertThat(addProduct.get().getPrice()).isEqualTo(reqDto.getProductDto().getPrice());
+    assertThat(addProduct.get().getText()).isEqualTo(reqDto.getProductDto().getText());
+    assertThat(addProduct.get().getStatus()).isEqualTo(reqDto.getProductDto().getStatus());
+    assertThat(addProduct.get().getImage()).isEqualTo(reqDto.getProductDto().getImageUrl());
   }
 
   @Test
   @DisplayName("상품 등록 실패 - 중복된 상품명")
-  @Transactional
   void product_save_fail() {
     // given
     Long userId = 1L;
+    AddProductReqDto reqDto = makeAddProductReqDto(store.getStoreId(), "치즈 떡볶이", 2, 5500);
+    Product product = makeAddProduct(reqDto);
 
-    AddProductReqDto reqDto = makeAddProductReqDto("치즈 떡볶이", 2, 5500);
+    productRepository.save(product);
 
-
-    // when
-    productService.addProduct(userId, reqDto);
-
-    //then
-    Assertions.assertThrows(CustomException.class,
-        ()-> productService.addProduct(userId, reqDto));
+    // when, then
+    assertThrows(CustomException.class,
+        () -> productService.addProduct(userId, reqDto));
   }
 
-  private AddProductReqDto makeAddProductReqDto(String productName, Integer quantity, Integer price) {
+  @Test
+  @DisplayName("상품 수정 성공")
+  void product_update() {
+    //given
+    Long userId = 1L;
+    UpdateProductReqDto reqDto = makeUpdateProductReqDto("치즈 떡볶이", 4, 5500);
+    Product product = makeUpdateProduct(reqDto);
+
+    Product addProduct = productRepository.save(product);
+
+    UpdateProductReqDto changeDto = makeUpdateProductReqDto("마라 떡볶이", 6, 3300);
+
+    //when
+    UpdateProductResDto resDto = productService.updateProduct(userId, addProduct.getProductId(),
+        changeDto);
+
+    //then
+    assertThat(changeDto.getProductDto().getProductName()).isEqualTo(
+        resDto.getProductDto().getProductName());
+    assertThat(changeDto.getProductDto().getQuantity()).isEqualTo(
+        resDto.getProductDto().getQuantity());
+    assertThat(changeDto.getProductDto().getPrice()).isEqualTo(resDto.getProductDto().getPrice());
+    assertThat(changeDto.getProductDto().getText()).isEqualTo(resDto.getProductDto().getText());
+    assertThat(changeDto.getProductDto().getStatus()).isEqualTo(resDto.getProductDto().getStatus());
+    assertThat(changeDto.getProductDto().getImageUrl()).isEqualTo(
+        resDto.getProductDto().getImageUrl());
+  }
+
+  @Test
+  @DisplayName("상품 수정 실패 - 변경하는 상품명이 이미 존재")
+  void product_update_fail() {
+    //given
+    Long userId = 1L;
+    UpdateProductReqDto reqDto1 = makeUpdateProductReqDto("치즈 떡볶이", 4, 5500);
+    Product product1 = makeUpdateProduct(reqDto1);
+    Product addProduct1 = productRepository.save(product1);
+
+    UpdateProductReqDto reqDto2 = makeUpdateProductReqDto("마라 떡볶이", 3, 4500);
+    Product product2 = makeUpdateProduct(reqDto2);
+    Product addProduct2 = productRepository.save(product2);
+
+    UpdateProductReqDto changeDto = makeUpdateProductReqDto("마라 떡볶이", 6, 3300);
+
+    //when
+    CustomException e = assertThrows(CustomException.class,
+        () -> productService.updateProduct(userId, addProduct1.getProductId(),
+            changeDto));
+    assertEquals(ALREADY_EXIST_PRODUCT.getMessage(), e.getErrorCode().getMessage());
+  }
+
+  private AddProductReqDto makeAddProductReqDto(UUID storeId, String productName, Integer quantity,
+      Integer price) {
     ProductDto productDto = ProductDto.builder()
         .productName(productName)
         .quantity(quantity)
@@ -76,9 +149,111 @@ class ProductServiceTest {
         .build();
 
     return AddProductReqDto.builder()
-        .storeId(UUID.fromString("d730d003-2956-47a6-9041-4c100dd1833e"))
+        .storeId(storeId)
         .productDto(productDto)
         .build();
   }
 
+  @Nested
+  @DisplayName("상품 삭제 테스트")
+  class DeleteProduct {
+
+    Long userId = 1L;
+    Product product;
+
+    @Test
+    @DisplayName("상품 삭제 실패 - 상품 미존재")
+    void product_delete_fail() {
+      //given
+      product = makeProduct("치즈 떡볶이", 4, 5000);
+      Product saveProduct = productRepository.save(product);
+
+      //when, then
+      CustomException e = assertThrows(CustomException.class,
+          () -> productService.deleteProduct(userId, store.getStoreId(), UUID.randomUUID()));
+      assertEquals(PRODUCT_NOT_FOUND.getMessage(), e.getErrorCode().getMessage());
+    }
+
+    @Test
+    @DisplayName("상품 삭제 성공 - 삭제 레코드는 조회 안됨.")
+    void product_delete() {
+      //given
+      product = makeProduct("치즈 떡볶이", 4, 5000);
+      Product saveProduct = productRepository.save(product);
+
+      //when
+      productService.deleteProduct(userId, store.getStoreId(), saveProduct.getProductId());
+
+      //then
+      Optional<Product> checkProduct = productRepository.findByProductIdAndStore_storeId(
+          saveProduct.getProductId(), store.getStoreId());
+      assertThat(checkProduct.isPresent()).isFalse();
+    }
+  }
+
+  private Product makeAddProduct(AddProductReqDto reqDto) {
+    return Product.builder()
+        .productName(reqDto.getProductDto().getProductName())
+        .quantity(reqDto.getProductDto().getQuantity())
+        .price(reqDto.getProductDto().getPrice())
+        .text(reqDto.getProductDto().getText())
+        .status(reqDto.getProductDto().getStatus())
+        .image(reqDto.getProductDto().getImageUrl())
+        .store(store)
+        .build();
+  }
+
+  private Product makeUpdateProduct(UpdateProductReqDto reqDto) {
+    return Product.builder()
+        .productName(reqDto.getProductDto().getProductName())
+        .quantity(reqDto.getProductDto().getQuantity())
+        .price(reqDto.getProductDto().getPrice())
+        .text(reqDto.getProductDto().getText())
+        .status(reqDto.getProductDto().getStatus())
+        .image(reqDto.getProductDto().getImageUrl())
+        .store(store)
+        .build();
+  }
+
+  private UpdateProductReqDto makeUpdateProductReqDto(String productName, Integer quantity,
+      Integer price) {
+    UpdateProductReqDto.ProductDto productDto = UpdateProductReqDto.ProductDto.builder()
+        .productName(productName)
+        .quantity(quantity)
+        .price(price)
+        .text("TEST")
+        .status(ProductStatus.SALE)
+        .imageUrl("TESTURL")
+        .build();
+
+    return UpdateProductReqDto.builder()
+        .storeId(store.getStoreId())
+        .productDto(productDto)
+        .build();
+  }
+
+  private Store makeStore() {
+    return Store.builder()
+        .storeName("신전 떡볶이")
+        .storeAddress("Test 주소")
+        .storeDetail("떡볶이 파는 곳")
+        .storeNumber("010-2334-3442")
+        .category(StoreCategory.분식)
+        .openTime(LocalTime.now())
+        .closedTime(LocalTime.now())
+        .isOpen(StoreIsOpen.OPEN)
+        .build();
+  }
+
+  private Product makeProduct(String productName, Integer quantity, Integer price) {
+    return Product.builder()
+        .productName(productName)
+        .quantity(quantity)
+        .price(price)
+        .text("TEST")
+        .status(ProductStatus.SALE)
+        .image("TESTURL")
+        .store(store)
+        .build();
+  }
 }

--- a/src/test/java/com/business/i4_be/domain/product/service/ProductServiceUnitTest.java
+++ b/src/test/java/com/business/i4_be/domain/product/service/ProductServiceUnitTest.java
@@ -1,6 +1,8 @@
 package com.business.i4_be.domain.product.service;
 
+import static com.business.i4_be.global.exception.ErrorCode.ALREADY_EXIST_PRODUCT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -9,9 +11,17 @@ import com.business.i4_be.domain.product.constants.ProductStatus;
 import com.business.i4_be.domain.product.dto.AddProductReqDto;
 import com.business.i4_be.domain.product.dto.AddProductReqDto.ProductDto;
 import com.business.i4_be.domain.product.dto.AddProductResDto;
+import com.business.i4_be.domain.product.dto.UpdateProductReqDto;
+import com.business.i4_be.domain.product.dto.UpdateProductResDto;
 import com.business.i4_be.domain.product.entity.Product;
 import com.business.i4_be.domain.product.repository.ProductRepository;
+import com.business.i4_be.domain.store.constant.StoreCategory;
+import com.business.i4_be.domain.store.constant.StoreIsOpen;
+import com.business.i4_be.domain.store.entity.Store;
+import com.business.i4_be.domain.store.repository.StoreRepository;
 import com.business.i4_be.global.exception.CustomException;
+import java.time.LocalTime;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,9 +29,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class ProductServiceUnitTest {
+
+  @Mock
+  StoreRepository storeRepository;
 
   @Mock
   ProductRepository productRepository;
@@ -32,12 +47,14 @@ class ProductServiceUnitTest {
   @Test
   @DisplayName("상품 등록 성공")
   void product_save() {
-
     // given
     Long userId = 1L;
 
     AddProductReqDto reqDto = makeAddProductReqDto("치즈 떡볶이", 2, 5500);
-    Product product = makeProduct(reqDto);
+    Product product = makeAddProduct(reqDto);
+    Store store = makeStore(reqDto.getStoreId());
+
+    given(storeRepository.findById(reqDto.getStoreId())).willReturn(Optional.ofNullable(store));
 
     given(productRepository.existsByProductName(reqDto.getProductDto().getProductName()))
         .willReturn(Boolean.FALSE);
@@ -48,28 +65,107 @@ class ProductServiceUnitTest {
     AddProductResDto resDto = productService.addProduct(userId, reqDto);
 
     // then
-    assertThat(resDto).isNotNull();
+    assertThat(reqDto.getProductDto().getProductName()).isEqualTo(
+        resDto.getProductDto().getProductName());
+    assertThat(reqDto.getProductDto().getQuantity()).isEqualTo(
+        resDto.getProductDto().getQuantity());
+    assertThat(reqDto.getProductDto().getPrice()).isEqualTo(resDto.getProductDto().getPrice());
+    assertThat(reqDto.getProductDto().getText()).isEqualTo(resDto.getProductDto().getText());
+    assertThat(reqDto.getProductDto().getStatus()).isEqualTo(resDto.getProductDto().getStatus());
+    assertThat(reqDto.getProductDto().getImageUrl()).isEqualTo(
+        resDto.getProductDto().getImageUrl());
   }
 
   @Test
   @DisplayName("상품 등록 실패 - 중복된 상품명")
   void product_save_fail() {
-
     // given
     Long userId = 1L;
 
     AddProductReqDto reqDto = makeAddProductReqDto("치즈 떡볶이", 2, 5500);
+
+    Store store = makeStore(reqDto.getStoreId());
+    given(storeRepository.findById(reqDto.getStoreId())).willReturn(Optional.ofNullable(store));
+
     given(productRepository.existsByProductName(reqDto.getProductDto().getProductName()))
         .willReturn(Boolean.TRUE);
 
     // when, then
-    assertThrows(CustomException.class, () ->
+    CustomException e = assertThrows(CustomException.class, () ->
         productService.addProduct(userId, reqDto));
+    assertEquals(ALREADY_EXIST_PRODUCT.getMessage(), e.getMessage());
   }
 
-  private Product makeProduct(AddProductReqDto reqDto) {
+  @Test
+  @DisplayName("상품 수정 성공")
+  void product_update() {
+    //given
+    Long userId = 1L;
+    UpdateProductReqDto reqDto = makeUpdateProductReqDto("치즈 떡볶이", 4, 5500);
+    Product product = makeUpdateProduct(reqDto);
+    given(productRepository.findByProductIdAndStore_storeId(product.getProductId(),
+        reqDto.getStoreId()))
+        .willReturn(Optional.of(product));
+
+    given(productRepository.existsByProductName(any()))
+        .willReturn(Boolean.FALSE);
+
+    UpdateProductReqDto changeDto = makeUpdateProductReqDto("마라 떡볶이", 4, 2000);
+
+    //when
+    UpdateProductResDto resDto = productService.updateProduct(userId, product.getProductId(),
+        changeDto);
+
+    //then
+    assertThat(changeDto.getProductDto().getProductName()).isEqualTo(
+        resDto.getProductDto().getProductName());
+    assertThat(changeDto.getProductDto().getQuantity()).isEqualTo(
+        resDto.getProductDto().getQuantity());
+    assertThat(changeDto.getProductDto().getPrice()).isEqualTo(resDto.getProductDto().getPrice());
+    assertThat(changeDto.getProductDto().getText()).isEqualTo(resDto.getProductDto().getText());
+    assertThat(changeDto.getProductDto().getStatus()).isEqualTo(resDto.getProductDto().getStatus());
+    assertThat(changeDto.getProductDto().getImageUrl()).isEqualTo(
+        resDto.getProductDto().getImageUrl());
+  }
+
+  @Test
+  @DisplayName("상품 수정 실패 - 변경하는 상품명이 이미 존재")
+  void product_update_fail() {
+    Long userId = 1L;
+    UpdateProductReqDto reqDto = makeUpdateProductReqDto("치즈 떡볶이", 4, 5500);
+    Product product = makeUpdateProduct(reqDto);
+    given(productRepository.findByProductIdAndStore_storeId(product.getProductId(),
+        reqDto.getStoreId()))
+        .willReturn(Optional.of(product));
+
+    given(productRepository.existsByProductName(any()))
+        .willReturn(Boolean.TRUE);
+
+    UpdateProductReqDto changeDto = makeUpdateProductReqDto("마라 떡볶이", 4, 5500);
+
+    // when, then
+    CustomException e = assertThrows(CustomException.class, () ->
+        productService.updateProduct(userId, product.getProductId(), changeDto));
+    assertEquals(ALREADY_EXIST_PRODUCT.getMessage(), e.getMessage());
+  }
+
+  private Store makeStore(UUID storeId) {
+    return Store.builder()
+        .storeId(storeId)
+        .storeName("신전 떡볶이")
+        .storeAddress("Test 주소")
+        .storeDetail("떡볶이 파는 곳")
+        .storeNumber("010-2334-3442")
+        .category(StoreCategory.분식)
+        .openTime(LocalTime.now())
+        .closedTime(LocalTime.now())
+        .isOpen(StoreIsOpen.OPEN)
+        .build();
+  }
+
+  private Product makeAddProduct(AddProductReqDto reqDto) {
     return Product.builder()
-        .productId(UUID.fromString("619cfbcd-f25b-4a29-b973-154ee1736da7"))
+        .productId(UUID.randomUUID())
         .productName(reqDto.getProductDto().getProductName())
         .quantity(reqDto.getProductDto().getQuantity())
         .price(reqDto.getProductDto().getPrice())
@@ -79,7 +175,8 @@ class ProductServiceUnitTest {
         .build();
   }
 
-  private AddProductReqDto makeAddProductReqDto(String productName, Integer quantity, Integer price) {
+  private AddProductReqDto makeAddProductReqDto(String productName, Integer quantity,
+      Integer price) {
     ProductDto productDto = ProductDto.builder()
         .productName(productName)
         .quantity(quantity)
@@ -90,6 +187,35 @@ class ProductServiceUnitTest {
         .build();
 
     return AddProductReqDto.builder()
+        .storeId(UUID.fromString("d730d003-2956-47a6-9041-4c100dd1833e"))
+        .productDto(productDto)
+        .build();
+  }
+
+  private Product makeUpdateProduct(UpdateProductReqDto reqDto) {
+    return Product.builder()
+        .productId(UUID.randomUUID())
+        .productName(reqDto.getProductDto().getProductName())
+        .quantity(reqDto.getProductDto().getQuantity())
+        .price(reqDto.getProductDto().getPrice())
+        .text(reqDto.getProductDto().getText())
+        .status(reqDto.getProductDto().getStatus())
+        .image(reqDto.getProductDto().getImageUrl())
+        .build();
+  }
+
+  private UpdateProductReqDto makeUpdateProductReqDto(String productName, Integer quantity,
+      Integer price) {
+    UpdateProductReqDto.ProductDto productDto = UpdateProductReqDto.ProductDto.builder()
+        .productName(productName)
+        .quantity(quantity)
+        .price(price)
+        .text("TEST")
+        .status(ProductStatus.SALE)
+        .imageUrl("TESTURL")
+        .build();
+
+    return UpdateProductReqDto.builder()
         .storeId(UUID.fromString("d730d003-2956-47a6-9041-4c100dd1833e"))
         .productDto(productDto)
         .build();


### PR DESCRIPTION
### 📌 작업 내용
이 PR에서 추가된 기능 또는 수정 사항에 대해 간략히 설명해주세요.
- As-is
  - (변경 전 설명을 여기에 작성)
- To-be
  - Product 도메인의 등록, 수정, 삭제의 테스트를 진행했습니다. 

### 🧑‍💻 작업 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 설정 변경
- [ ] CI/CD 변경

### 📷 관련 이미지
해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### 🚨 주의 사항
- 테스트를 진행하면서 알게 된 내용이 있어서 관련된 변경점이 있습니다.
1. 배경 : 테스트에 @Transactional을 달면 각 테스트마다 Rollback을 할 수 있고, 테스트 메서드까지 트랜잭션을 확장 할 수 있기 때문에 지연로딩 예외를 방지할 수 있습니다. 하지만 이로 인해 두 가지 문제점이 있습니다.

a. 서비스 로직에서 @Transactional을 빼먹거나, readOnly같으 옵션이 있을 때 덮어쓰기가 될 수 있습니다. 이로 인해 실제 로직과 차이가 발생할 수 있습니다.
b. 서비스와 다르게 테스트에서는 트랜잭션이 롤백 됩니다. 따라서 update 할 때 실제와 차이가 날 수 있습니다. 

2. 변경 : 테스트에서 @Transactional을 쓰지 않으면, Test DB가 공유 되면서 이전 테스트에 영향을 미치게 됩니다. 따라서 이전 테스트에서 저장된 데이터 때문에 중복 검사같은 부분에서 예외가 발생할 수 있습니다. 그래서 매 테스트마다 DB를 초기화 하는 방법이 필요합니다. 이 때 deleteAll()을 호출하면 외래키 제약 조건으로 정상적인 삭제가 안되는 경우가 있습니다. 

3. 방법 :  NativeQuery를 이용해서 DB를 삭제하는 TearDownExecutor 클래스를 만들었습니다. 이것은 Entity에 해당하는 테이블을 모아서 리스트에 담습니다. 그리고 execute()메서드에서 리스트를 순회해서 외래키 제약 비활성화 -> 테이블 데이터 삭제 -> 외래키 제약 활성화 과정을 거쳐서 모든 테이블의 데이터를 삭제합니다. 

4. 사용법 : DeleteSupport 클래스를 상속받으면 자동으로 실행됩니다. 이 때, test용 스키마를 test로 지었습니다. 지금은 상수로 TearDownExecutor에 test 스키마를 명시하고 있는데, yml파일에서 각자의 스키마로 받아서 활용할 수 도 있습니다. 
![image](https://github.com/user-attachments/assets/d45f4814-9790-4f8b-8694-09a18ea685f7)

5. 참고 : 설명이 잘된 블로그가 있어서 공유합니다.
https://velog.io/@backfox/%EA%B9%80%EC%B6%98%EB%B0%B0%EC%99%80-%EC%95%8C%EC%95%84%EB%B3%B4%EB%8A%94-Transactional-%EC%9D%B4%EB%AA%A8%EC%A0%80%EB%AA%A8-1-%ED%85%8C%EC%8A%A4%ED%8A%B8%EC%BD%94%EB%93%9C


### 🤔 토론
기능을 추가하면서 생긴 고민을 작성해주세요.
